### PR TITLE
Add tmux-powerkit plugin with tokyo-night theme

### DIFF
--- a/scripts/check-mcp-installed.sh
+++ b/scripts/check-mcp-installed.sh
@@ -624,6 +624,12 @@ main() {
         return 0
       fi
       ;;
+
+    *)
+      log_error "Unknown config type: $CONFIG_TYPE"
+      log_info "Valid types: claude-desktop, cursor, vscode, boltai, project, claude-cli, all"
+      return 1
+      ;;
   esac
 
   return $exit_code

--- a/tools/tmux/tmux.conf
+++ b/tools/tmux/tmux.conf
@@ -46,21 +46,6 @@ set-option -g base-index 1
 set-window-option -g pane-base-index 1
 set-window-option -g mouse on
 
-# color scheme (styled as vim-powerline)
-set -g status-left-length 52
-set -g status-right-length 451
-set -g status-style fg=white,bg=colour234
-set -g pane-border-style fg=colour245
-set -g pane-active-border-style fg=colour39
-set -g message-style fg=colour16,bg=colour221,bold
-set -g status-left '#[fg=colour235,bg=colour252,bold] ❐ #S #[fg=colour252,bg=colour238,nobold]⮀#[fg=colour245,bg=colour238,bold] #(whoami) #[fg=colour238,bg=colour234,nobold]⮀'
-set -g window-status-format '#[fg=colour235,bg=colour252,bold] #I #(pwd="#{pane_current_path}"; echo ${pwd####*/}) #W '
-set -g window-status-current-format '#[fg=colour234,bg=colour39]⮀#[fg=black,bg=colour39,noreverse,bold] #{?window_zoomed_flag,#[fg=colour228],} #I #(pwd="#{pane_current_path}"; echo ${pwd####*/}) #W #[fg=colour39,bg=colour234,nobold]⮀'
-set-option -g status-interval 2
-
-# Patch for OS X pbpaste and pbcopy under tmux.
-set-option -g default-command "which reattach-to-user-namespace > /dev/null && reattach-to-user-namespace -l $SHELL || $SHELL"
-
 # Screen like binding
 unbind C-b
 set -g prefix C-a
@@ -92,19 +77,12 @@ set -g @plugin 'tmux-plugins/tmux-sensible'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
 set -g @plugin 'tmux-plugins/tmux-continuum'
 set -g @plugin 'tmux-plugins/tmux-logging'
+set -g @plugin 'fabioluciano/tmux-powerkit'
 
-run '~/.tmux/plugins/tpm/tpm'
-
-# Local config
-if-shell "[ -f ~/.tmux.conf.user ]" 'source ~/.tmux.conf.user'
-
-# Fig Tmux Integration: Enabled
-source-file ~/.fig/tmux
-# End of Fig Tmux Integration
-
-# Status bar
-set -g status-style bg=black,fg=white
-set -g status-right "#[fg=green]#H #[fg=black]• #[fg=green]#(uname -r | cut -c 1-6)#[default]"
+# tmux-powerkit configuration
+set -g @powerkit_theme "tokyo-night"
+set -g @powerkit_separator_style "angular"
+set -g @powerkit_plugins "datetime,battery,cpu,memory,git"
 
 # Enable focus events
 set -g focus-events on
@@ -121,3 +99,9 @@ bind h select-pane -L
 bind j select-pane -D
 bind k select-pane -U
 bind l select-pane -R
+
+# Initialize TPM (keep this at the end)
+run '~/.tmux/plugins/tpm/tpm'
+
+# Local config
+if-shell "[ -f ~/.tmux.conf.user ]" 'source ~/.tmux.conf.user'


### PR DESCRIPTION
## Summary
Add tmux-powerkit status bar plugin to enhance tmux configuration with system monitoring and git integration. Cleaned up conflicting and outdated settings.

## Changes
- Added fabioluciano/tmux-powerkit with tokyo-night theme
- Enabled datetime, battery, cpu, memory, and git status plugins
- Removed old vim-powerline status bar configuration
- Removed outdated reattach-to-user-namespace workaround
- Removed non-functional Fig integration
- Reorganized config with proper TPM initialization at end

🤖 Generated with Claude Code