### PR TITLE
feat(headless): interactive 1Password service account token setup

### DIFF
--- a/.dotbot/configs/headless.yaml
+++ b/.dotbot/configs/headless.yaml
@@ -38,3 +38,13 @@
       description: Verify Tailscale + align node hostname to local $HOSTNAME
       stdin: true
       stderr: true
+
+    - command: |
+        # 1Password service account token: interactive prompt if not yet set.
+        # Writes ~/.config/op/token.sh (600), ensures ~/.zshrc sources it.
+        # No-op when already configured or when stdin isn't a tty.
+        ~/.dotfiles/tools/1password/service-account-install.sh
+      description: 1Password service account token (interactive)
+      stdin: true
+      stdout: true
+      stderr: true

--- a/.gitignore
+++ b/.gitignore
@@ -42,9 +42,12 @@ tools/claude/config.json
 tools/cursor-agent/config.json
 tools/1password/secret-paths.json
 
-# 1Password config (contains device/account IDs - should be per-user)
-tools/1password/
-!tools/1password/*.template
+# 1Password config (contains device/account IDs - should be per-user).
+# Scripts (.sh) and templates (.template) are shared; instance-specific
+# JSON/config files stay local.
+tools/1password/accounts.json
+tools/1password/config
+tools/1password/secret-paths.json
 
 # Claude AI configuration (personal settings)
 .claude/settings.local.json

--- a/tools/1password/service-account-install.sh
+++ b/tools/1password/service-account-install.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Interactive setup for a 1Password service account token on a headless Mac.
+# Prompts once per machine, writes ~/.config/op/token.sh (mode 600) and
+# ensures ~/.zshrc sources it on shell startup.
+#
+# Idempotent: re-running with a token already configured is a no-op.
+# Non-interactive: if stdin isn't a tty and no token exists, prints
+#   instructions and exits 0 (so dotbot doesn't fail the whole profile).
+#
+# Token creation (run on the admin laptop as a signed-in user):
+#   op --account <biz-account> service-account create <name> \
+#     --can-create-vaults --expires-in 2159h \
+#     --vault "Vault1:read_items,write_items" ...
+# 1P max expiry is ~90 days (2160h ceiling); rotate before it lapses.
+
+set -euo pipefail
+
+CFG_DIR="$HOME/.config/op"
+TOKEN_FILE="$CFG_DIR/token.sh"
+ZSHRC="$HOME/.zshrc"
+SOURCE_LINE='[[ -f ~/.config/op/token.sh ]] && source ~/.config/op/token.sh'
+
+log() { printf '[op-sa] %s\n' "$*" >&2; }
+
+mkdir -p "$CFG_DIR"
+chmod 700 "$CFG_DIR"
+
+ensure_zshrc_source() {
+  if [[ -f "$ZSHRC" ]] && grep -qF "op/token.sh" "$ZSHRC"; then
+    return 0
+  fi
+  {
+    printf '\n# 1Password service account token (headless profile)\n'
+    printf '%s\n' "$SOURCE_LINE"
+  } >> "$ZSHRC"
+  log "added source line to $ZSHRC"
+}
+
+token_configured() {
+  [[ -f "$TOKEN_FILE" ]] || return 1
+  grep -qE '^export OP_SERVICE_ACCOUNT_TOKEN=.+' "$TOKEN_FILE"
+}
+
+if token_configured; then
+  log "token already configured at $TOKEN_FILE; skipping prompt"
+  ensure_zshrc_source
+  exit 0
+fi
+
+if [[ ! -t 0 ]]; then
+  log "no token file and stdin is not a tty; skipping prompt"
+  log "to configure later, run: bash $0"
+  ensure_zshrc_source
+  exit 0
+fi
+
+cat >&2 <<'EOF'
+
+  1Password service account setup
+  -------------------------------
+  Paste the service account token (starts with ops_...).
+  Stored at ~/.config/op/token.sh (mode 600). Leave blank to skip.
+
+EOF
+printf '  token: ' >&2
+# -s hides input; -r disables backslash mangling.
+read -rs token
+printf '\n' >&2
+
+if [[ -z "${token:-}" ]]; then
+  log "skipped (no token entered)"
+  ensure_zshrc_source
+  exit 0
+fi
+
+if [[ "$token" != ops_* ]]; then
+  log "warning: token doesn't start with 'ops_' — writing anyway"
+fi
+
+umask 077
+printf 'export OP_SERVICE_ACCOUNT_TOKEN=%q\n' "$token" > "$TOKEN_FILE"
+chmod 600 "$TOKEN_FILE"
+unset token
+log "token written to $TOKEN_FILE (mode 600)"
+
+ensure_zshrc_source
+
+log "open a new shell, or run: source ~/.config/op/token.sh && op whoami"


### PR DESCRIPTION
## Summary
Adds a prompt-on-first-run step to the `headless` profile that captures an `OP_SERVICE_ACCOUNT_TOKEN` from the operator and writes it to `~/.config/op/token.sh` (mode 600), ensuring `~/.zshrc` sources it going forward.

## Why
On headless Macs (e.g., clamshelled M2 Max serving as a dev box via Tailscale), the biometric / desktop-app flow for `op` isn't usable from a remote SSH session. A 1Password service account token is the right credential — long-lived, no biometric, env-var based. This adds the scaffolding to prompt for the token once, persist it with correct permissions, and leave the actual token out of any repo (including dotfiles-private).

## What's in
- `tools/1password/service-account-install.sh` — idempotent prompt; skips cleanly when a token is already configured or when stdin isn't a tty.
- `.dotbot/configs/headless.yaml` — wires the script as the last step of the headless profile (after tailscale).
- `.gitignore` — replace the blanket `tools/1password/` ignore with per-file patterns so shared scripts can be versioned while instance-local config (`accounts.json`, `config`, `secret-paths.json`) stays local.

## How tokens are created (context, not part of this PR)
On the admin laptop, signed in to the relevant business 1Password account:
```
op --account <biz-acct> service-account create <name> \
  --can-create-vaults --expires-in 2159h \
  --vault 'Vault A:read_items,write_items' \
  --vault 'Vault B:read_items,write_items' ...
```
1P's `--expires-in` ceiling is 2160 hours (~90 days); rotate before it lapses by creating a new SA and revoking the old one in the web UI (no CLI revoke yet).

## Testing
- [x] Dry-run `bash tools/1password/service-account-install.sh` when `~/.config/op/token.sh` is already populated → logs "already configured", exits 0, still ensures zshrc source line.
- [x] Dry-run when stdin is not a tty → logs "not a tty", exits 0, still ensures zshrc source line.
- [ ] Full `./install profile headless` run on a fresh headless Mac → prompt appears after tailscale step, token captured, `op whoami` works from a new shell.

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: pure additive dotbot step, no runtime impact beyond user-interactive bootstrap on headless boxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)