### PR TITLE
fix(asdf): support asdf 0.16+ (Go binary, no asdf.sh)

### DIFF
--- a/.dotbot/configs/asdf.yaml
+++ b/.dotbot/configs/asdf.yaml
@@ -1,20 +1,24 @@
 - shell:
     - command: |
-        # Validate and source asdf
+        # Validate asdf is installed. asdf >= 0.16 is a Go binary with no
+        # asdf.sh shim source — PATH integration via ~/.asdf/shims is all
+        # that's needed. Legacy asdf (<= 0.15) had a sourceable shim, but
+        # that path no longer exists with current Homebrew formula.
         BREW_PREFIX=$(brew --prefix 2>/dev/null || echo "/opt/homebrew")
-
-        if [ -f "$BREW_PREFIX/opt/asdf/libexec/asdf.sh" ]; then
+        if [ -x "$BREW_PREFIX/bin/asdf" ]; then
+          echo "✅ asdf found at $BREW_PREFIX/bin/asdf ($($BREW_PREFIX/bin/asdf --version))"
+        elif [ -f "$BREW_PREFIX/opt/asdf/libexec/asdf.sh" ]; then
+          # Legacy fallback for boxes still on asdf <= 0.15
           . "$BREW_PREFIX/opt/asdf/libexec/asdf.sh"
-          echo "✅ asdf loaded successfully"
+          echo "✅ asdf (legacy) loaded successfully"
         else
-          echo "⚠️  WARNING: asdf not found at $BREW_PREFIX/opt/asdf"
+          echo "⚠️  WARNING: asdf not found"
           echo "Skipping asdf setup. Install with:"
           echo "  brew install asdf"
           exit 0
         fi
-      description: Validate and source asdf with error handling
+      description: Validate asdf install (0.16+ binary, with legacy fallback)
 
 - link:
     ~/.asdfrc: tools/asdf/asdfrc
     ~/.tool-versions: tools/asdf/tool-versions
-    ~/.asdf/asdf.sh: /opt/homebrew/opt/asdf/libexec/asdf.sh 

--- a/.dotbot/configs/languages/go.yaml
+++ b/.dotbot/configs/languages/go.yaml
@@ -1,8 +1,8 @@
 - shell:
     - command: |
-        . /opt/homebrew/opt/asdf/libexec/asdf.sh
+        export PATH="/opt/homebrew/bin:$HOME/.asdf/shims:$PATH"
         asdf plugin add golang || true
-        asdf plugin update golang
+        asdf plugin update golang || true
         asdf install golang 1.22.0
         asdf set -u golang 1.22.0
         

--- a/.dotbot/configs/languages/nodejs.yaml
+++ b/.dotbot/configs/languages/nodejs.yaml
@@ -1,15 +1,13 @@
 - shell:
-    - command: >
-        . /opt/homebrew/opt/asdf/libexec/asdf.sh
+    - command: |
+        # asdf 0.16+ is a Go binary; PATH integration is enough.
+        export PATH="/opt/homebrew/bin:$HOME/.asdf/shims:$PATH"
         asdf plugin add nodejs || true
-        asdf plugin update nodejs
+        asdf plugin update nodejs || true
         asdf install nodejs 20.19.1
         asdf set -u nodejs 20.19.1
-        # Ensure the new version is active and available
         asdf reshim nodejs
-        export PATH="$HOME/.asdf/shims:$PATH"
-        export PATH="$HOME/.asdf/bin:$PATH"
-        
+
         # Install global npm packages
         npm install -g npm@10.2.4
         npm install -g yarn

--- a/.dotbot/configs/languages/python.yaml
+++ b/.dotbot/configs/languages/python.yaml
@@ -1,9 +1,9 @@
 - shell:
       - command: |
             echo "Setting up Python with asdf..."
-            . /opt/homebrew/opt/asdf/libexec/asdf.sh
+            export PATH="/opt/homebrew/bin:$HOME/.asdf/shims:$PATH"
             asdf plugin add python || true
-            asdf plugin update python
+            asdf plugin update python || true
             asdf install python 3.13.8
             asdf set -p python 3.13.8
         description: Set up Python with asdf

--- a/.dotbot/configs/languages/ruby.yaml
+++ b/.dotbot/configs/languages/ruby.yaml
@@ -1,8 +1,8 @@
 - shell:
     - command: |
-        . /opt/homebrew/opt/asdf/libexec/asdf.sh
+        export PATH="/opt/homebrew/bin:$HOME/.asdf/shims:$PATH"
         asdf plugin add ruby || true
-        asdf plugin update ruby
+        asdf plugin update ruby || true
         asdf install ruby 3.3.0
         asdf set -u ruby 3.3.0
         

--- a/.dotbot/configs/languages/rust.yaml
+++ b/.dotbot/configs/languages/rust.yaml
@@ -1,8 +1,8 @@
 - shell:
     - command: |
-        . /opt/homebrew/opt/asdf/libexec/asdf.sh
+        export PATH="/opt/homebrew/bin:$HOME/.asdf/shims:$PATH"
         asdf plugin add rust || true
-        asdf plugin update rust
+        asdf plugin update rust || true
         asdf install rust 1.91.1
         asdf set -u rust 1.91.1
 

--- a/shells/oh-my-zsh/custom/functions.zsh
+++ b/shells/oh-my-zsh/custom/functions.zsh
@@ -190,10 +190,12 @@ function asdf-upgrade() {
         esac
     done
 
-    # Ensure asdf is available
+    # Ensure asdf is available (0.16+ is a Go binary on PATH).
     if ! command -v asdf &>/dev/null; then
-        if [[ -f "$HOME/.asdf/asdf.sh" ]]; then
-            source "$HOME/.asdf/asdf.sh"
+        if [[ -x "/opt/homebrew/bin/asdf" ]]; then
+            export PATH="/opt/homebrew/bin:$HOME/.asdf/shims:$PATH"
+        elif [[ -f "$HOME/.asdf/asdf.sh" ]]; then
+            source "$HOME/.asdf/asdf.sh"  # legacy asdf <= 0.15
         else
             _asdf_log_error "asdf not found. Please install asdf first."
             return 1

--- a/shells/zsh/zsh.before/asdf.zsh
+++ b/shells/zsh/zsh.before/asdf.zsh
@@ -1,7 +1,5 @@
-. $HOME/.asdf/asdf.sh
-
-# # append completions to fpath
-fpath=(${ASDF_DIR}/completions $fpath)
-
-# # initialise completions with ZSH's compinit
+# asdf 0.16+ is a Go binary on PATH; only thing left to do here is wire up
+# the shims directory and completions.
+export PATH="$HOME/.asdf/shims:$PATH"
+fpath=("${ASDF_DATA_DIR:-$HOME/.asdf}/completions" $fpath)
 autoload -Uz compinit && compinit -C

--- a/shells/zsh/zshrc
+++ b/shells/zsh/zshrc
@@ -60,13 +60,16 @@ for file in ~/.zsh.after/*.zsh; do
 done
 unsetopt nullglob
 
+# --- asdf 0.16+ ---
+# Modern asdf is a Go binary on PATH; no shim source. Just expose its shims dir.
+export PATH="$HOME/.asdf/shims:$PATH"
+
 # --- Lazy load ---
 asdf() {
     unfunction asdf
-    . $HOME/.asdf/asdf.sh
-    fpath=(${ASDF_DIR}/completions $fpath)
+    fpath=("${ASDF_DATA_DIR:-$HOME/.asdf}/completions" $fpath)
     autoload -Uz compinit && compinit -C
-    asdf "$@"
+    command asdf "$@"
 }
 
 direnv() {

--- a/shells/zsh/zshrc.minimal
+++ b/shells/zsh/zshrc.minimal
@@ -54,14 +54,16 @@ alias gp='git push'
 alias gl='git log --oneline'
 alias gd='git diff'
 
+# asdf 0.16+ is a Go binary on PATH; just expose its shims.
+export PATH="$HOME/.asdf/shims:$PATH"
+
 # Lazy load everything else
-# ASDF - load only when asdf command is used
+# ASDF - load completions on first invocation
 asdf() {
     unfunction asdf
-    . $HOME/.asdf/asdf.sh
-    fpath=(${ASDF_DIR}/completions $fpath)
+    fpath=("${ASDF_DATA_DIR:-$HOME/.asdf}/completions" $fpath)
     autoload -Uz compinit && compinit -C
-    asdf "$@"
+    command asdf "$@"
 }
 
 # Direnv - load only when direnv command is used

--- a/shells/zsh/zshrc.optimized
+++ b/shells/zsh/zshrc.optimized
@@ -44,14 +44,16 @@ for file in ~/.zsh.before/{1password,aliases,history,key-bindings,noglob,path,rm
     [[ -f "$file" ]] && source "$file"
 done
 
+# asdf 0.16+ is a Go binary on PATH; just expose its shims.
+export PATH="$HOME/.asdf/shims:$PATH"
+
 # Lazy load heavy components
-# ASDF - load only when needed
+# ASDF - load completions on first invocation
 asdf() {
     unfunction asdf
-    . $HOME/.asdf/asdf.sh
-    fpath=(${ASDF_DIR}/completions $fpath)
+    fpath=("${ASDF_DATA_DIR:-$HOME/.asdf}/completions" $fpath)
     autoload -Uz compinit && compinit -C
-    asdf "$@"
+    command asdf "$@"
 }
 
 # Direnv - load only when needed

--- a/shells/zsh/zshrc.ultra-fast
+++ b/shells/zsh/zshrc.ultra-fast
@@ -123,14 +123,16 @@ if command -v starship >/dev/null 2>&1; then
     eval "$(starship init zsh)"
 fi
 
+# asdf 0.16+ is a Go binary on PATH; just expose its shims.
+export PATH="$HOME/.asdf/shims:$PATH"
+
 # Lazy load heavy components
-# ASDF
+# ASDF (completion-only lazy load now that the binary lives on PATH)
 asdf() {
     unfunction asdf
-    . $HOME/.asdf/asdf.sh
-    fpath=(${ASDF_DIR}/completions $fpath)
+    fpath=("${ASDF_DATA_DIR:-$HOME/.asdf}/completions" $fpath)
     autoload -Uz compinit && compinit -C
-    asdf "$@"
+    command asdf "$@"
 }
 
 # Direnv


### PR DESCRIPTION
## Summary

Modern asdf installed via Homebrew (≥ 0.16) is a Go binary — no `asdf.sh` shim
script to source. The dotfiles still try to source `$BREW_PREFIX/opt/asdf/libexec/asdf.sh`
at multiple points, which now hard-fails on a fresh box because that path
doesn't exist:

- Dotbot `asdf.yaml` had a literal symlink `~/.asdf/asdf.sh -> /opt/homebrew/opt/asdf/libexec/asdf.sh`
  that fails with "Nonexistent target".
- Each language config (nodejs/python/ruby/go/rust) ran `. /opt/homebrew/opt/asdf/libexec/asdf.sh`
  before any `asdf install`, then exited the step.
- All four `zshrc` variants and `zsh.before/asdf.zsh` lazy-loaded asdf by sourcing the same path.

## Changes

- Drop the dead symlink in `asdf.yaml` and validate via the `asdf` binary.
- Language steps export `PATH=/opt/homebrew/bin:$HOME/.asdf/shims:$PATH` instead of sourcing.
- zshrc variants set `PATH=$HOME/.asdf/shims:$PATH` at file scope and switch lazy-loaders to `command asdf` (so completions still load on first invocation, but no `source` is needed).
- Keep a legacy fallback path for boxes still on asdf ≤ 0.15.

## Testing

Discovered while bootstrapping a fresh M2 (`jbc-dev-mac`) — dotbot step 60 failed
with "Nonexistent target ~/.asdf/asdf.sh -> /opt/homebrew/opt/asdf/libexec/asdf.sh".
After this fix, dotbot completes step 60, and `asdf --version` works in fresh shells.

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Logs: dotbot output during `./install profile full`
  - Behavior: `asdf --version`, `asdf current`, asdf-managed binaries on PATH in fresh shells
- **Validation checks**
  - `./install profile full` — should not error on `~/.asdf/asdf.sh`
  - `asdf --version` returns 0.16+ in a fresh shell
  - shims dir on PATH in zsh
- **Expected healthy behavior**: dotbot step 60 completes; shimmed binaries (node, python, ruby, go, rust) resolve via `~/.asdf/shims`.
- **Failure signal / rollback**: any "asdf.sh: No such file" still appearing in `./install` output → revert this PR; rollback is just `git revert`.
- **Validation window & owner**: 24h after merge / @joelbcastillo

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)