### PR TITLE
fix(python): commit pipx config.json + pin shared venv to python@3.13

### DIFF
--- a/.dotbot/configs/languages/python.yaml
+++ b/.dotbot/configs/languages/python.yaml
@@ -7,6 +7,22 @@
             asdf install python 3.13.8
             asdf set -p python 3.13.8
         description: Set up Python with asdf
+      - command: |
+            # pipx ships pinned to whichever python brew picked at install time.
+            # On fresh boxes that's python@3.14, whose ensurepip is broken under
+            # current Homebrew. Force pipx onto python@3.13 by recreating the
+            # shared venv when it points at a non-functional interpreter.
+            PIPX_PY313="/opt/homebrew/opt/python@3.13/bin/python3.13"
+            if [ -x "$PIPX_PY313" ]; then
+              SHARED_CFG="$HOME/.local/pipx/shared/pyvenv.cfg"
+              if [ ! -f "$SHARED_CFG" ] || ! grep -q "python@3.13" "$SHARED_CFG"; then
+                echo "Recreating pipx shared venv with python@3.13..."
+                rm -rf "$HOME/.local/pipx/shared"
+                "$PIPX_PY313" -m venv "$HOME/.local/pipx/shared"
+                "$HOME/.local/pipx/shared/bin/python" -m pip install --upgrade pip pipx
+              fi
+            fi
+        description: Pin pipx shared venv to python@3.13
 
 - link:
       ~/.pip/pip.conf:

--- a/tools/pipx/config.json
+++ b/tools/pipx/config.json
@@ -1,0 +1,10 @@
+{
+  "venvs_dir": "~/.local/pipx/venvs",
+  "bin_dir": "~/.local/bin",
+  "python": "python3",
+  "pip_args": [
+    "--no-cache-dir",
+    "--disable-pip-version-check"
+  ],
+  "verbose": false
+} 


### PR DESCRIPTION
## Summary

Two bootstrap-blocker fixes for fresh M2 setups:

1. **Commit `tools/pipx/config.json`** — this file was present on existing boxes but never tracked, so dotbot's `link:` target was missing on a fresh clone (`Nonexistent target ~/.config/pipx/config.json -> tools/pipx/config.json`), which causes the python language step to report "Some links were not successfully set up" → step exit non-zero → bootstrap halt.
2. **Pin pipx's shared venv to python@3.13** — on a fresh `brew install pipx`, pipx is installed against the current default `python@3.14`, whose `ensurepip --default-pip` is broken under the current Homebrew formula. Every `pipx install <pkg>` then explodes with `Command '...python3.14 -m ensurepip ...' returned non-zero exit status 1`. Recreate the shared venv with `/opt/homebrew/opt/python@3.13/bin/python3.13` before the pipx requirements step runs. Idempotent — only fires when the shared venv is missing or not pointing at python@3.13.

## Testing

- ✅ Existing boxes: pipx shared venv already on python@3.13 → recreate step is a no-op.
- ✅ Fresh M2 reproduction: bootstrap step 60 was failing because of both issues; this PR resolves both.

## Post-Deploy Monitoring & Validation

- **What to watch**: `~/bootstrap.log` on M2 for the python language step
- **Expected healthy signals**: `Recreating pipx shared venv with python@3.13...` (first-run on fresh box) or silent skip (steady state); no `Nonexistent target ~/.config/pipx/config.json` line
- **Failure signal / rollback trigger**: `Command '...python3.14 -m ensurepip...' returned non-zero exit status` reappears OR step 60 still fails
- **Validation window & owner**: next bootstrap rerun on jbc-dev-mac (joel)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)