### PR TITLE
fix(python): patch pyexpat dylib for macOS 26 (Tahoe)

### DIFF
--- a/.dotbot/configs/languages/python.yaml
+++ b/.dotbot/configs/languages/python.yaml
@@ -8,10 +8,27 @@
             asdf set -p python 3.13.8
         description: Set up Python with asdf
       - command: |
+            # macOS 26 (Tahoe) ships an older system libexpat than the brew
+            # python@3.13/3.14 bottles were built against. pyexpat.so links to
+            # /usr/lib/libexpat.1.dylib and fails to find the new symbol
+            # _XML_SetAllocTrackerActivationThreshold, breaking ensurepip,
+            # pipx, and anything that imports xml.parsers.expat. Patch the
+            # dylib reference to the brew expat version and re-sign.
+            brew list expat >/dev/null 2>&1 || brew install expat
+            for PYV in 3.13 3.14; do
+              PYEXPAT=$(ls /opt/homebrew/Cellar/python@${PYV}/*/Frameworks/Python.framework/Versions/${PYV}/lib/python${PYV}/lib-dynload/pyexpat.cpython-${PYV/./}-darwin.so 2>/dev/null | head -1)
+              [ -n "$PYEXPAT" ] || continue
+              if otool -L "$PYEXPAT" 2>/dev/null | grep -q '/usr/lib/libexpat.1.dylib'; then
+                echo "Patching pyexpat for python@${PYV} -> brew libexpat..."
+                install_name_tool -change /usr/lib/libexpat.1.dylib /opt/homebrew/opt/expat/lib/libexpat.1.dylib "$PYEXPAT" 2>/dev/null
+                codesign --force -s - "$PYEXPAT" 2>/dev/null
+              fi
+            done
+        description: Patch pyexpat to use brew libexpat (macOS 26 workaround)
+      - command: |
             # pipx ships pinned to whichever python brew picked at install time.
-            # On fresh boxes that's python@3.14, whose ensurepip is broken under
-            # current Homebrew. Force pipx onto python@3.13 by recreating the
-            # shared venv when it points at a non-functional interpreter.
+            # On fresh boxes that's python@3.14. Force pipx onto python@3.13
+            # by recreating the shared venv when it points elsewhere.
             PIPX_PY313="/opt/homebrew/opt/python@3.13/bin/python3.13"
             if [ -x "$PIPX_PY313" ]; then
               SHARED_CFG="$HOME/.local/pipx/shared/pyvenv.cfg"


### PR DESCRIPTION
## Summary

macOS 26.x ships an older system libexpat than brew's `python@3.13/3.14` bottles were compiled against. On a fresh install, `pyexpat.so` fails to dlopen with:

```
Symbol not found: _XML_SetAllocTrackerActivationThreshold
```

This breaks `ensurepip`, `pipx --version`, `python -m pip`, and anything that imports `xml.parsers.expat`.

This patch rewrites `pyexpat.so`'s dylib reference from `/usr/lib/libexpat.1.dylib` to `/opt/homebrew/opt/expat/lib/libexpat.1.dylib` (which matches the build expat the bottle was compiled against) and re-signs with an ad-hoc identity.

## Why

Without this, `pipx install` and any subsequent Python tooling install fails on Tahoe with cryptic dlopen errors. The fix is small and targeted; the alternative (rebuilding python@3.13 from source) is excessive.

## How

- `brew install expat` if not present
- For both `3.13` and `3.14` (fresh boxes land on 3.14 first):
  - Locate `pyexpat.cpython-<ver>-darwin.so` under brew's Python framework
  - Run `install_name_tool -change /usr/lib/libexpat.1.dylib /opt/homebrew/opt/expat/lib/libexpat.1.dylib`
  - `codesign --force -s -` to re-sign

Idempotent: `otool -L | grep` guards against re-patching, `brew install` is no-op when present.

## Testing

Verified on `jbc-dev-mac` (macOS 26.2 / Apple Silicon):

```
$ python3.13 -c 'from xml.parsers import expat; print(expat.EXPAT_VERSION)'
expat_2.8.0
$ pipx --version
1.7.1
```

Both fail without the patch and succeed after it. Pre-existing patched installs are untouched (idempotent guard).

## Post-Deploy Monitoring & Validation

`No additional operational monitoring required: dotfiles install is run interactively per-machine; failure is immediately visible to the operator. Patch is idempotent and only runs when brew's pyexpat.so still references /usr/lib/libexpat.`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)