### PR TITLE
fix(zsh): prevent shell hangs on headless / service-account hosts

### DIFF
--- a/.dotbot/configs/oh-my-zsh.yaml
+++ b/.dotbot/configs/oh-my-zsh.yaml
@@ -21,13 +21,6 @@
         fi
     description: Install Oh My Zsh and required plugins
 
-- shell:
-  -
-    command: |
-      echo 'export SHELL=/opt/homebrew/bin/zsh' >> ~/.zshrc
-      echo 'exec /opt/homebrew/bin/zsh -l' >> ~/.zshrc
-    description: Set ZSH as default shell
-
 - link:
     ~/.oh-my-zsh/custom: shells/oh-my-zsh/custom
     ~/.zsh.after: shells/zsh/zsh.after

--- a/shells/zsh/zshenv
+++ b/shells/zsh/zshenv
@@ -44,10 +44,14 @@ if command -v op >/dev/null 2>&1 && [ -z "$GITHUB_PERSONAL_ACCESS_TOKEN" ]; then
         export GITHUB_PERSONAL_ACCESS_TOKEN="$(cat "$_gh_token_cache")"
         export GITHUB_TOKEN="$GITHUB_PERSONAL_ACCESS_TOKEN"
         export GH_TOKEN="$GITHUB_PERSONAL_ACCESS_TOKEN"
-    elif op account list >/dev/null 2>&1; then
-        # Fetch from 1Password and cache
+    elif [ -z "$OP_SERVICE_ACCOUNT_TOKEN" ] && op account list >/dev/null 2>&1; then
+        # Fetch from 1Password and cache.
+        # Skipped when running under a service-account token (headless mode):
+        # SA tokens are scoped to a single account and cannot resolve
+        # cross-account vault refs, which causes `op read` to hang.
+        # `timeout 5` is a safety net for biometric prompts that never get answered.
         mkdir -p "$HOME/.cache"
-        _token="$(op read --account jbctechsolutions.1password.com "op://Local Dev/GitHub PAT - Claude Code/credential" 2>/dev/null)"
+        _token="$(timeout 5 op read --account jbctechsolutions.1password.com "op://Local Dev/GitHub PAT - Claude Code/credential" 2>/dev/null)"
         if [ -n "$_token" ]; then
             echo "$_token" > "$_gh_token_cache"
             chmod 600 "$_gh_token_cache"


### PR DESCRIPTION
## Summary

Two compounding bugs caused interactive ssh into the headless M2 to hang ~2 minutes per session. Both fixed here:

### 1. `oh-my-zsh.yaml` recursive `exec zsh` (the recursion)

The block wrote two lines into `~/.zshrc`:

```
export SHELL=/opt/homebrew/bin/zsh
exec /opt/homebrew/bin/zsh -l
```

But `zsh.yaml` symlinks `~/.zshrc -> shells/zsh/zshrc`, so the redirect appended into the dotfiles source itself. Every subsequent interactive shell then `exec`-d another interactive shell — infinite recursion until the system gave up.

`zsh.yaml` already does `chsh -s /opt/homebrew/bin/zsh`, so the whole block is redundant. Dropped.

> Note: `ai-tools.yaml:15` and `cursor-agent.yaml:15` have the same `>> ~/.zshrc` antipattern (PATH exports). Less dangerous since they don't `exec`, but they still corrupt the dotfiles source over time. Worth a follow-up.

### 2. `shells/zsh/zshenv` `op read --account` hang

The 1Password lookup runs on every shell init. Under `OP_SERVICE_ACCOUNT_TOKEN` (headless mode), the SA token is scoped to a single account and cannot resolve a vault ref pinned to a different account name, so `op` blocks ~60 seconds waiting for it to appear in `op account list`. With the recursion bug above, that 60s ran twice per ssh.

Fix:
- Skip the lookup entirely when `OP_SERVICE_ACCOUNT_TOKEN` is set (SA hosts can't reach this vault anyway).
- Wrap the call in `timeout 5` as a safety net for biometric prompts that never get answered.

## Testing

- [x] YAML still parses (`ruby -ryaml` confirms 3 top-level entries)
- [x] Diff scoped to two files; no behavior change on biometric/agent hosts when 1P is unlocked
- [ ] Will validate on M2 after merge: `time ssh joel@jbc-dev-mac '...zsh -ic exit'` should drop from ~120s to <2s

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Manual: `time ssh joel@<headless-host> 'zsh -ic exit'` from the laptop
- **Validation checks**
  - `time zsh -ic exit` on the headless box should be <2s (currently ~120s)
  - `time zsh -c exit` should remain ~3s (already bounded by `timeout 3` hot-patch; this PR drops it to ~0.1s under SA mode)
  - Biometric host (laptop): no behavior change when 1P unlocked; on locked-1P state, `op read` returns within 5s instead of blocking until biometric is provided
- **Expected healthy behavior**
  - SA-token hosts: no `op` invocation in zshenv path
  - Biometric hosts: same as before, with a 5s ceiling
- **Failure signal / rollback trigger**
  - If biometric users report missing `GITHUB_PERSONAL_ACCESS_TOKEN` after first shell of the day, drop the `timeout 5` (let it block until biometric resolves)
  - If `chsh` on a fresh machine doesn't take effect after dotbot run, the dropped block was actually doing something — restore it but use `tee -a` against a non-symlinked file
- **Validation window & owner**
  - Window: next dotbot rerun on M2 + first interactive ssh
  - Owner: @joelbcastillo

## Before / After

Before (M2):
\`\`\`
$ time ssh joel@jbc-dev-mac 'zsh -ic "echo READY"'
READY
ssh ...  0.05s user 0.04s system 0% cpu 2:02.47 total
\`\`\`

After (expected):
\`\`\`
$ time ssh joel@jbc-dev-mac 'zsh -ic "echo READY"'
READY
ssh ...  ~1s total
\`\`\`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)