### PR TITLE
fix(dotbot): stop appending to ~/.zshrc from install scripts

### DIFF
--- a/.dotbot/configs/ai-tools.yaml
+++ b/.dotbot/configs/ai-tools.yaml
@@ -10,11 +10,9 @@
       if ! command -v cursor-agent >/dev/null 2>&1; then
         echo "Installing cursor-agent..."
         curl https://cursor.com/install -fsS | bash
-        # Add ~/.local/bin to PATH if not already there
-        if ! echo "$PATH" | grep -q "$HOME/.local/bin"; then
-          echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
-          export PATH="$HOME/.local/bin:$PATH"
-        fi
+        # ~/.local/bin is already on PATH via shells/zsh/zshenv.
+        # Export it for this dotbot session so the verify step below can find cursor-agent.
+        export PATH="$HOME/.local/bin:$PATH"
       else
         echo "cursor-agent is already installed"
       fi

--- a/.dotbot/configs/cursor-agent.yaml
+++ b/.dotbot/configs/cursor-agent.yaml
@@ -10,11 +10,9 @@
       if ! command -v cursor-agent >/dev/null 2>&1; then
         echo "Installing cursor-agent..."
         curl https://cursor.com/install -fsS | bash
-        # Add ~/.local/bin to PATH if not already there
-        if ! echo "$PATH" | grep -q "$HOME/.local/bin"; then
-          echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
-          export PATH="$HOME/.local/bin:$PATH"
-        fi
+        # ~/.local/bin is already on PATH via shells/zsh/zshenv.
+        # Export it for this dotbot session so the verify step below can find cursor-agent.
+        export PATH="$HOME/.local/bin:$PATH"
       else
         echo "cursor-agent is already installed"
       fi


### PR DESCRIPTION
## Summary

Two install configs ran `echo 'export PATH=...' >> ~/.zshrc`:

- `.dotbot/configs/ai-tools.yaml:15`
- `.dotbot/configs/cursor-agent.yaml:15`

Because `zsh.yaml` symlinks `~/.zshrc -> shells/zsh/zshrc`, the redirect wrote into the dotfiles source itself. Every dotbot run that took the install branch (cursor-agent missing) appended a duplicate line to the tracked file. Same antipattern as the recursive `exec zsh` block we removed in #30 — less dangerous (no recursion) but still pollutes the repo over time.

The export is already set in `shells/zsh/zshenv:9`:

```sh
export PATH="$HOME/.local/bin:$PATH"
```

…so the appended lines were redundant from day one. Drop the redirect, keep the in-process `export` so the dotbot session's verify step can still find the freshly installed binary.

## Testing

- [x] YAML parses (`ruby -ryaml` confirms 5 / 6 top-level entries)
- [x] `shells/zsh/zshrc` source is clean of accumulated `export PATH="$HOME/.local/bin:$PATH"` lines
- [x] `~/.local/bin` already in PATH via zshenv

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this only affects dotbot install scripts; on next dotbot rerun the install branch is a no-op (cursor-agent already installed) so the change has no observable effect on existing machines. New installs get the same end state without polluting the source file.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)