### PR TITLE
fix(zsh): guard 1Password SSH agent socket export for headless hosts

### DIFF
--- a/shells/zsh/zshrc
+++ b/shells/zsh/zshrc
@@ -28,8 +28,16 @@ else
 fi
 export VISUAL="$EDITOR"
 
-# 1Password SSH Agent Configuration
-export SSH_AUTH_SOCK=~/Library/Group\ Containers/2BUA8C4S2C.com.1password/t/agent.sock
+# 1Password SSH Agent Configuration.
+# Guard for headless / GUI-less hosts where the 1Password app isn't running:
+# pointing SSH_AUTH_SOCK at a nonexistent socket makes ssh-add / git fall over
+# with confusing "communication with agent failed" errors. Only export when
+# the socket actually exists.
+_op_ssh_sock="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+if [[ -S "$_op_ssh_sock" ]]; then
+  export SSH_AUTH_SOCK="$_op_ssh_sock"
+fi
+unset _op_ssh_sock
 
 # --- OMZ & prompt ---
 if [[ -f "$ZSH/oh-my-zsh.sh" ]]; then

--- a/shells/zsh/zshrc.ultra-fast
+++ b/shells/zsh/zshrc.ultra-fast
@@ -109,8 +109,10 @@ alias rm='nocorrect rm'
 # Zoxide aliases
 alias cdi="zi"
 
-# 1Password SSH Agent Configuration
-export SSH_AUTH_SOCK=~/Library/Group\ Containers/2BUA8C4S2C.com.1password/t/agent.sock
+# 1Password SSH Agent Configuration. Guard for headless hosts (see zshrc).
+_op_ssh_sock="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+[[ -S "$_op_ssh_sock" ]] && export SSH_AUTH_SOCK="$_op_ssh_sock"
+unset _op_ssh_sock
 
 # Fig shell integration (minimal)
 [ -s ~/.fig/shell/pre.sh ] && source ~/.fig/shell/pre.sh


### PR DESCRIPTION
## Summary

`SSH_AUTH_SOCK` was unconditionally pointed at the 1Password macOS app's group container socket:

```sh
export SSH_AUTH_SOCK=~/Library/Group\ Containers/2BUA8C4S2C.com.1password/t/agent.sock
```

On a headless box (the new `jbc-dev-mac`) the 1Password app isn't running, the socket doesn't exist, and `ssh-add` / `git push` / anything that wants the agent fails with `communication with agent failed` instead of falling back to the system ssh-agent or just running without one.

Guard the export so `SSH_AUTH_SOCK` only gets set when the socket actually exists. Apply the same guard to `shells/zsh/zshrc.ultra-fast`.

On a normal laptop with the 1Password app running this is a no-op; on a headless host it lets ssh fall through to whatever agent is otherwise configured (or no agent).

## Testing

- [x] `zsh -n` syntax-checks both files
- [x] Manual verification on M2 (headless): socket file does NOT exist, so the export is skipped; `git`/`ssh` no longer reference a dead agent
- [x] Manual verification on laptop: socket exists, behavior unchanged

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Manual: on the laptop, run `echo \$SSH_AUTH_SOCK` after re-sourcing zshrc — should still print the 1Password path
  - Manual: on a headless host, the variable should be unset (no agent), and `ssh -A` flows should be the only path that uses an agent
- **Expected healthy behavior**
  - Laptop: identical to before
  - Headless: no `communication with agent failed` errors from `git` or `ssh-add`
- **Failure signal / rollback trigger**
  - If laptop users see git/ssh suddenly prompt for keys after a fresh shell, `\$HOME` or socket path expansion broke — revert
- **Validation window & owner**
  - Window: next interactive shell on each host
  - Owner: @joelbcastillo

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)