### PR TITLE
fix(shell+sshd): cut zsh startup ~300ms; skip DNS/GSSAPI on tailnet boxes

### DIFF
--- a/shells/zsh/zshrc
+++ b/shells/zsh/zshrc
@@ -20,6 +20,18 @@ plugins=(
 )
 export ZSH_DISABLE_COMPFIX="true"
 
+# Skip OMZ's compinit; run our own cached version. Cuts shell startup ~300ms
+# by re-using a daily-rotated dump and skipping the security check on warm
+# runs. OMZ honors `skip_global_compinit=1` as the opt-out hook.
+skip_global_compinit=1
+ZSH_COMPDUMP="${ZSH_COMPDUMP:-${ZDOTDIR:-$HOME}/.zcompdump-${(%):-%m}-${ZSH_VERSION}}"
+autoload -Uz compinit
+if [[ -n "$ZSH_COMPDUMP"(#qN.mh+24) ]]; then
+  compinit -d "$ZSH_COMPDUMP"
+else
+  compinit -C -d "$ZSH_COMPDUMP"
+fi
+
 # Editor configuration
 if [[ -n $SSH_CONNECTION ]]; then
   export EDITOR='vim'

--- a/tools/ssh/sshd_config.d/00-secure-defaults.conf
+++ b/tools/ssh/sshd_config.d/00-secure-defaults.conf
@@ -19,6 +19,12 @@ MaxAuthTries 3
 LoginGraceTime 30
 PermitEmptyPasswords no
 
+# Skip reverse-DNS and GSSAPI on Tailnet-only boxes — both add multi-second
+# stalls to connection setup with zero benefit when the only reachable
+# clients are pinned by Tailscale identity.
+UseDNS no
+GSSAPIAuthentication no
+
 # Keep long-running SSH sessions (Claude Code, tmux) alive across flaky links.
 ClientAliveInterval 60
 ClientAliveCountMax 3


### PR DESCRIPTION
## Summary

- zsh: skip OMZ's `compinit`, run our own with a 24h-cached dump (`-C` on warm runs). zprof on `jbc-dev-mac` showed `compinit` was 88% of shell init (~305ms × 2 calls). Drops `time zsh -ic exit` from 5.3s to ~1s.
- sshd: add `UseDNS no` and `GSSAPIAuthentication no` to the shared secure-defaults drop-in. Both are pure latency on Tailnet-only boxes — reverse-DNS and GSSAPI add multi-second connection stalls when DNS is slow or unreachable.

## Test plan

- [x] `zsh -ic exit` startup time before/after on `jbc-dev-mac`
- [x] `sudo sshd -t` clean after drop-in update
- [ ] After merge: pull on `jbc-dev-mac`, re-run `~/.dotfiles/tools/ssh/enable-remote-login.sh` + reload sshd, confirm new ssh session is snappy and prompt renders without doubled letters