### PR TITLE
revert(zsh): drop skip_global_compinit guard; OMZ ignores it

### DIFF
--- a/shells/zsh/zshrc
+++ b/shells/zsh/zshrc
@@ -20,18 +20,6 @@ plugins=(
 )
 export ZSH_DISABLE_COMPFIX="true"
 
-# Skip OMZ's compinit; run our own cached version. Cuts shell startup ~300ms
-# by re-using a daily-rotated dump and skipping the security check on warm
-# runs. OMZ honors `skip_global_compinit=1` as the opt-out hook.
-skip_global_compinit=1
-ZSH_COMPDUMP="${ZSH_COMPDUMP:-${ZDOTDIR:-$HOME}/.zcompdump-${(%):-%m}-${ZSH_VERSION}}"
-autoload -Uz compinit
-if [[ -n "$ZSH_COMPDUMP"(#qN.mh+24) ]]; then
-  compinit -d "$ZSH_COMPDUMP"
-else
-  compinit -C -d "$ZSH_COMPDUMP"
-fi
-
 # Editor configuration
 if [[ -n $SSH_CONNECTION ]]; then
   export EDITOR='vim'


### PR DESCRIPTION
## Summary

Reverts the `.zshrc` half of #34. `skip_global_compinit=1` is not honored by this OMZ build — OMZ calls compinit unconditionally at `oh-my-zsh.sh:127`. The custom compinit added a third call on top of OMZ's two; zprof confirmed startup time was unchanged.

The sshd dropin half of #34 (`UseDNS no`, `GSSAPIAuthentication no`) is unaffected and remains.

## Test plan

- [x] `git diff main` shows only the zsh block removed
- [ ] After merge: pull on `jbc-dev-mac`, confirm `~/.zshrc` no longer has the compinit block