### PR TITLE
perf(zsh): disable OMZ inline update check + drop redundant compinit

### DIFF
--- a/shells/zsh/zsh.before/asdf.zsh
+++ b/shells/zsh/zsh.before/asdf.zsh
@@ -1,5 +1,5 @@
 # asdf 0.16+ is a Go binary on PATH; only thing left to do here is wire up
-# the shims directory and completions.
+# the shims directory and completions. The compinit call is OMZ's job —
+# running it again here was a redundant ~150ms per shell.
 export PATH="$HOME/.asdf/shims:$PATH"
 fpath=("${ASDF_DATA_DIR:-$HOME/.asdf}/completions" $fpath)
-autoload -Uz compinit && compinit -C

--- a/shells/zsh/zshrc
+++ b/shells/zsh/zshrc
@@ -20,6 +20,14 @@ plugins=(
 )
 export ZSH_DISABLE_COMPFIX="true"
 
+# Disable OMZ's auto-update check at shell init. It's run inline (blocks
+# new shells) and on stale caches it shells out to git/network, which on
+# the headless box was contributing seconds of wall-clock delay. Run
+# `omz update` manually when needed.
+DISABLE_AUTO_UPDATE="true"
+DISABLE_UPDATE_PROMPT="true"
+zstyle ':omz:update' mode disabled
+
 # Editor configuration
 if [[ -n $SSH_CONNECTION ]]; then
   export EDITOR='vim'


### PR DESCRIPTION
## Summary

Two targeted cuts at zsh startup time on `jbc-dev-mac` (was 5.3s `zsh -ic exit`):

- `~/.zsh.before/asdf.zsh` ran `compinit -C` redundantly with OMZ's compinit. zprof showed compinit being called twice — this was the second one. ~150ms reclaimed.
- OMZ's `tools/check_for_upgrade.sh` runs inline at shell init and shells out to git/network on a stale cache. zprof only saw 408ms of function time vs 5.3s wall clock — most of the missing 4.9s lives in this kind of inline I/O. Disabled via documented zstyle + legacy env knobs. `omz update` still works manually.

## Test plan

- [ ] After merge: pull on `jbc-dev-mac`, measure `time zsh -ic exit` — expect well under 5s, hopefully ~1s
- [ ] Confirm tab-completion still works in a fresh shell
- [ ] Confirm `asdf <tab>` still completes versions