### PR TITLE
fix(zshenv): load OP_SERVICE_ACCOUNT_TOKEN before GitHub-PAT block

### DIFF
--- a/shells/zsh/zshenv
+++ b/shells/zsh/zshenv
@@ -5,6 +5,12 @@ export LC_ALL=en_US.UTF-8
 # Set dotfiles directory
 export DOTFILES="$HOME/.dotfiles"
 
+# Headless / service-account hosts: load OP_SERVICE_ACCOUNT_TOKEN if it has
+# been provisioned. Must come BEFORE the GitHub-PAT block below — that block
+# uses [ -z "$OP_SERVICE_ACCOUNT_TOKEN" ] to skip an `op read` that otherwise
+# hangs on its 5s timeout (no GUI app to answer biometric auth, every shell).
+[ -f "$HOME/.config/op/token.sh" ] && . "$HOME/.config/op/token.sh"
+
 # Add local bin to PATH
 export PATH="$HOME/.local/bin:$PATH"
 


### PR DESCRIPTION
## Summary

Every interactive shell on the headless box took **5.25s** to start. Bisection localized it to `~/.zshenv`. The GitHub-PAT block has the right guard (`[ -z "\$OP_SERVICE_ACCOUNT_TOKEN" ]`), but the SA token file at `~/.config/op/token.sh` was being written by the rotation script and **never sourced anywhere**. Result: guard didn't trip, `op read` ran, no GUI to answer biometric, hung to its 5s `timeout`. Every shell.

Loads the token file at the top of `.zshenv` if it exists. Guard now trips on SA hosts; no-op on machines without the file.

## Test plan

- [x] `zsh -f -ic exit` (skip .zshenv): 340ms — clean
- [x] `zsh -d -ic exit` (only .zshenv runs): 5240ms — confirmed culprit
- [x] `OP_SERVICE_ACCOUNT_TOKEN` was unset in interactive shell pre-fix
- [ ] After merge: pull on `jbc-dev-mac`, expect `time zsh -ic exit` < 1s