### PR TITLE
feat(shell): add mac-reboot helper for headless tailnet macs

### DIFF
--- a/shells/zsh/zsh.after/mac-reboot.zsh
+++ b/shells/zsh/zsh.after/mac-reboot.zsh
@@ -1,0 +1,15 @@
+# mac-reboot — planned reboot of a headless Mac that skips the FileVault
+# unlock prompt on next boot. Uses `fdesetup authrestart`, which keeps the
+# disk key in memory across the restart so sshd comes back up immediately
+# and the box is reachable again without anyone at the console.
+#
+# Usage: mac-reboot [hostname]   (default: jbc-dev-mac)
+#
+# Requires: sudo on the remote host (you'll be prompted via ssh -t).
+
+mac-reboot() {
+  local host="${1:-jbc-dev-mac}"
+
+  printf 'rebooting %s now (FileVault skipped on next boot via authrestart)...\n' "$host"
+  ssh -t "$host" 'sudo fdesetup authrestart -delayminutes 0'
+}


### PR DESCRIPTION
## Summary

Adds a `mac-reboot [host]` zsh function that runs `sudo fdesetup authrestart -delayminutes 0` on the named host (default `jbc-dev-mac`). authrestart skips the FileVault unlock prompt on next boot, so the headless Mac comes back online over SSH without anyone at the console.

Sibling to the existing `mac-up` function. `mac-up` to check, `mac-reboot` to cycle.

## Test plan

- [ ] After merge: pull on the laptop, `which mac-reboot` resolves
- [ ] `mac-reboot jbc-dev-mac` prompts for sudo, then box comes back online and `mac-up` reports `online` within ~60s