### PR TITLE
feat: support 1Password service-account mode for headless installs

### DIFF
--- a/scripts/fetch-ssh-keys.sh
+++ b/scripts/fetch-ssh-keys.sh
@@ -132,6 +132,17 @@ setup_ssh_key() {
 
 # Main function
 main() {
+    # Service-account mode early-exit. SA tokens are scoped to a single
+    # 1Password account and can't drive `op signin --account`, so the
+    # multi-account key fetch below is a non-starter. On headless boxes the
+    # operator agent-forwards SSH from the laptop instead, so missing
+    # ~/.ssh/keys/* is benign.
+    if command -v op >/dev/null 2>&1 && op whoami 2>/dev/null | grep -q SERVICE_ACCOUNT; then
+        echo "Detected 1Password service-account mode — skipping multi-account SSH key fetch."
+        echo "Use SSH agent forwarding from the laptop for git pushes from this host."
+        return 0
+    fi
+
     # Legacy mode - old single-key behavior
     if [ "$LEGACY_MODE" = true ]; then
         echo "Setting up SSH key from 1Password (legacy mode)..."

--- a/tools/git/gitconfig
+++ b/tools/git/gitconfig
@@ -189,5 +189,3 @@
 	format = ssh
 [commit]
 	gpgsign = true
-[url "https://github.com/"]
-	insteadOf = git@github.com:


### PR DESCRIPTION
## Summary
Two changes that together let \`./install private\` run on a headless Mac under \`OP_SERVICE_ACCOUNT_TOKEN\`:

1. **Drop the \`url.https://github.com/.insteadOf=git@github.com:\` rewrite** in \`tools/git/gitconfig\`. It silently sabotaged SSH-via-agent-forwarding clones on the headless box (the agent-forwarded \`git@...\` URL got rewritten to HTTPS, then failed because no creds were available).
2. **\`fetch-ssh-keys.sh\` early-exits when \`op whoami\` reports \`SERVICE_ACCOUNT\`.** The multi-account \`op signin --account\` flow can't run under an SA token. On headless boxes the operator agent-forwards SSH from the laptop, so missing \`~/.ssh/keys/*\` is benign.

## Why
Discovered while trying to install \`dmux\` on jbc-dev-mac — the alias (\`_secure_run ai dmux\`) lives in \`.dotfiles-private/aliases/claude-auth.zsh\`, which had been deliberately skipped on headless boxes. Audit of \`setup-private-files.sh\` showed it has zero \`op\` calls; the only SA-incompatible code path is \`fetch-ssh-keys.sh\`, which is reachable through \`./install profile full\` regardless. Easier to fix it directly than route around the whole flow.

## Test plan
- [x] Validated SSH clone of private repo via agent-forwarded ssh from jbc-dev-mac (\`git clone --quiet git@github.com:.../dotfiles-private.git\` → succeeds after rewrite removed)
- [x] \`bash -n\` clean on \`fetch-ssh-keys.sh\`
- [ ] After deploy: \`./install private\` runs cleanly on jbc-dev-mac, \`dmux\` alias appears
- [ ] Laptop git operations still work (1P SSH agent should cover SSH everywhere)

## Companion PR
Pairs with [jbctechsolutions/jbc-dev-laptop#2](https://github.com/jbctechsolutions/jbc-dev-laptop/pull/2) which un-skips the private clone + \`./install private\` in 60-dotfiles.sh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)