### PR TITLE
fix(install-private): link shells/secure_profiles → oh-my-zsh/custom

### DIFF
--- a/scripts/setup-private-files.sh
+++ b/scripts/setup-private-files.sh
@@ -55,6 +55,7 @@ get_target_dir() {
         azure) echo "tools/azure" ;;
         docker) echo "tools/docker" ;;
         kubernetes) echo "tools/kubernetes" ;;
+        shells/secure_profiles) echo "shells/oh-my-zsh/custom/secure_profiles" ;;
         *) echo "" ;;
     esac
 }
@@ -72,6 +73,7 @@ PRIVATE_SUBDIRS=(
     "azure"
     "docker"
     "kubernetes"
+    "shells/secure_profiles"
 )
 
 # Link files from a directory with optional prefix


### PR DESCRIPTION
## Summary
- `setup-private-files.sh` had a hardcoded directory map that omitted `shells/secure_profiles`, so `./install private` never linked the `_secure_run` profiles (ai, aws, jbctech_cloud, …) into `shells/oh-my-zsh/custom/secure_profiles/`.
- Symptom on a fresh Mac: `dmux` (which is `_secure_run ai dmux`) failed with `Error: Profile 'ai' not found at .../secure_profiles/ai`.
- Adds `shells/secure_profiles` to `PRIVATE_SUBDIRS` + `get_target_dir`. The existing `link_directory_files` helper already handles arbitrary target depths via `mkdir -p`, and the source resolution accepts paths with slashes.

## Why this matters
This was the missing piece that prevented headless Mac bootstrap (jbc-dev-laptop) from producing a working `dmux` / secure profile setup without manual symlinking.

## Test plan
- [x] On laptop: rerun `./install private`, observe new `Linking shells/secure_profiles/ → shells/oh-my-zsh/custom/secure_profiles/` log line, confirm symlinks for ai/aws/jbctech_cloud are recreated cleanly.
- [ ] On jbc-dev-mac: rerun `./install private` and confirm secure_profiles symlinks appear without manual intervention.
- [ ] After merge, re-run `bash scripts/60-dotfiles.sh` on a fresh-ish Mac to confirm end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)