### PR TITLE
fix(install): skip spinner when stdout isn't a TTY

### DIFF
--- a/install
+++ b/install
@@ -31,7 +31,7 @@ SPINNER_PID=""
 function spinner() {
     local msg="$1"
     local delay=0.1
-    
+
     # Start spinner
     while true; do
         printf "\r${BLUE}[%c] %s${NC}" "${SPINNER_CHARS:$SPINNER_POS:1}" "$msg"
@@ -40,11 +40,18 @@ function spinner() {
     done
 }
 
+# The spinner uses tput civis/cnorm to hide/show the cursor. Both require a
+# usable TERM and an actual terminal — over a non-interactive ssh
+# (e.g. `ssh host './install …'` from a bootstrap script) TERM is unset and
+# tput dies, which under `set -e` (or a parent script with errexit) silently
+# kills whatever step is running. Skip the whole spinner when stdout isn't a
+# TTY; nothing observes the cursor in that case anyway.
 function start_spinner() {
+    [ -t 1 ] || return 0
     spinner "$1" &
     SPINNER_PID=$!
     # Disable cursor
-    tput civis
+    tput civis 2>/dev/null || true
 }
 
 function stop_spinner() {
@@ -53,8 +60,9 @@ function stop_spinner() {
         wait "$SPINNER_PID" 2>/dev/null
         SPINNER_PID=""
     fi
+    [ -t 1 ] || return 0
     # Enable cursor
-    tput cnorm
+    tput cnorm 2>/dev/null || true
     # Clear the spinner line
     printf "\r\033[K"
 }


### PR DESCRIPTION
## Summary
- The spinner calls `tput civis` / `tput cnorm`, both of which need a usable TERM and a real terminal.
- Over a non-interactive ssh (e.g. `ssh host './install ...'` from a bootstrap script), TERM is empty → `tput` exits with `tput: No value for \$TERM and no -T specified` → under `set -e` (or a parent shell with errexit), the install step silently aborts mid-stream.
- Symptom: on a fresh headless Mac bootstrap (driven by `jbc-dev-laptop`'s `scripts/60-dotfiles.sh`), dotbot configs that should symlink `~/.tmux.conf`, tpm, `secure_profiles`, etc. were being skipped without a clear error.

## Fix
- Skip the whole spinner when stdout isn't a TTY (`[ -t 1 ]`) — nothing observes the cursor blink in that case.
- Harden cursor restore with `2>/dev/null || true` as belt-and-suspenders against weird TERM values.

## Test plan
- [x] Reproduced empty-TERM no-TTY scenario locally: `env -i HOME=\$HOME PATH=\$PATH bash -c './install config tmux'` now completes cleanly and produces the symlink.
- [ ] Re-run `bash scripts/60-dotfiles.sh` from `jbc-dev-laptop` against a Mac and confirm tmux + secure_profiles install on first pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)