### PR TITLE
chore(tmux): nord theme, status bar at bottom

### DIFF
--- a/tools/tmux/tmux.conf
+++ b/tools/tmux/tmux.conf
@@ -144,7 +144,12 @@ set -g @plugin 'tmux-plugins/tmux-logging'
 set -g @plugin 'fabioluciano/tmux-powerkit'
 
 # tmux-powerkit configuration
-set -g @powerkit_theme "tokyo-night"
+# Theme: nord/dark — cool blue/grey/teal palette, no purple accents.
+# Status bar at the bottom (powerkit defaults to top); explicit so the
+# preference doesn't drift if powerkit changes its default later.
+set -g @powerkit_theme "nord"
+set -g @powerkit_theme_variant "dark"
+set -g @powerkit_status_position "bottom"
 set -g @powerkit_separator_style "angular"
 set -g @powerkit_plugins "datetime,battery,cpu,memory,git"
 


### PR DESCRIPTION
## Summary
- Switch tmux-powerkit theme from `tokyo-night` (purple-heavy) to `nord/dark` (cool blue/grey/teal, no purple).
- Pin `@powerkit_status_position` to `bottom` (powerkit defaults to top).

## Test plan
- [x] Reloaded `~/.tmux.conf` on laptop. `tmux show-options -g` confirms `status-position bottom`, `@powerkit_theme nord`, `@powerkit_theme_variant dark`.
- [ ] Eyeball: status bar appears at bottom with nord palette, no purple segments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)