### PR TITLE
chore(tmux): switch theme to matte-black, document favorites

### DIFF
--- a/tools/tmux/tmux.conf
+++ b/tools/tmux/tmux.conf
@@ -144,11 +144,28 @@ set -g @plugin 'tmux-plugins/tmux-logging'
 set -g @plugin 'fabioluciano/tmux-powerkit'
 
 # tmux-powerkit configuration
-# Theme: nord/dark — cool blue/grey/teal palette, no purple accents.
+# Theme: matte-black/default — near-monochrome dark with subtle accents.
 # Status bar at the bottom (powerkit defaults to top); explicit so the
 # preference doesn't drift if powerkit changes its default later.
-set -g @powerkit_theme "nord"
-set -g @powerkit_theme_variant "dark"
+#
+# Favorites I've evaluated and want to keep handy. To try one live:
+#   tmux set -g @powerkit_theme NAME \; \
+#        set -g @powerkit_theme_variant VARIANT \; \
+#        source-file ~/.tmux.conf
+#
+#   github       dark
+#   onedark      dark
+#   abyss        dark
+#   ayu          dark      (also: light, mirage)
+#   material     default   (also: lighter, ocean, palenight)
+#   matte-black  default   ← current
+#   slack        dark
+#   starlight    dark
+#   lagoon       dark
+#   hackerman    default
+#   nord         dark
+set -g @powerkit_theme "matte-black"
+set -g @powerkit_theme_variant "default"
 set -g @powerkit_status_position "bottom"
 set -g @powerkit_separator_style "angular"
 set -g @powerkit_plugins "datetime,battery,cpu,memory,git"


### PR DESCRIPTION
## Summary
- Switch powerkit theme from `nord/dark` → `matte-black/default` (near-monochrome dark with subtle accents).
- Add a favorites comment block above the theme setting listing other themes I've vetted, with the live-swap one-liner inline. Saves digging through `~/.tmux/plugins/tmux-powerkit/src/themes/` next time I want to try one.

## Test plan
- [x] Live-applied via `tmux set -g @powerkit_theme matte-black ; source-file ~/.tmux.conf` on laptop — looks right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)