### PR TITLE
feat(zshenv): source op() wrapper for non-interactive shells

### DIFF
--- a/shells/zsh/zshenv
+++ b/shells/zsh/zshenv
@@ -11,6 +11,14 @@ export DOTFILES="$HOME/.dotfiles"
 # hangs on its 5s timeout (no GUI app to answer biometric auth, every shell).
 [ -f "$HOME/.config/op/token.sh" ] && . "$HOME/.config/op/token.sh"
 
+# Multi-account `op` wrapper. Lives in zsh.before for prezto-time setup, but
+# we also source it here from zshenv so non-interactive SSH commands like
+# `ssh jbc-dev-mac 'op --account joshuaproject vault list'` get the wrapper
+# (zshrc / zsh.before only run for interactive shells). The file is pure
+# function/export definitions — safe to source twice.
+[ -f "$HOME/.dotfiles/shells/zsh/zsh.before/1password.zsh" ] && \
+    . "$HOME/.dotfiles/shells/zsh/zsh.before/1password.zsh"
+
 # Add local bin to PATH
 export PATH="$HOME/.local/bin:$PATH"
 


### PR DESCRIPTION
## Summary

Source `shells/zsh/zsh.before/1password.zsh` from `zshenv` so the multi-account `op()` wrapper is defined in every zsh context, including non-interactive SSH commands.

## Why

The wrapper was previously only loaded via prezto's `zsh.before` hook chain, which only runs for interactive shells. Concretely:

```sh
ssh jbc-dev-mac 'op --account joshuaproject vault list'
```

…would bypass the wrapper, hit the real `op` binary, and ignore `--account` because `OP_SERVICE_ACCOUNT_TOKEN` was already in env (SA tokens are 1:1 with accounts — `op` can't switch out from under a token).

After this:
```sh
ssh jbc-dev-mac 'op --account joshuaproject vault list'  # → JP vaults
ssh jbc-dev-mac 'op vault list'                           # → default (jbc) vaults
```

## Implementation

One block added near the existing `~/.config/op/token.sh` source line in `zshenv`. Same file is still sourced via prezto in interactive shells; sourcing twice is harmless — pure function and export definitions.

## Test plan

- [ ] After dotfiles pull on the Mac: `ssh jbc-dev-mac 'op --account joshuaproject vault list'` returns JP vaults.
- [ ] On laptop: interactive shells still get the wrapper (prezto path), no double-prompt or duplicated env weirdness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)