### PR TITLE
fix(ssh): replace broken ln-sf wiring with native link + clean tracked symlinks

### DIFF
--- a/.dotbot/configs/private.yaml
+++ b/.dotbot/configs/private.yaml
@@ -2,6 +2,18 @@
 # This configuration creates symlinks to private files from the dotfiles-private repository
 # to the locations where the original dotbot configs expect them
 
+# Base SSH config: swap the regular file in for a symlink to the private
+# canonical. `force: true` is needed here exactly once — it overwrites a
+# drifted regular file on first run, then becomes a no-op (the `link.py`
+# idempotency check short-circuits). `canonicalize: false` preserves the
+# `~/...` target instead of resolving through `realpath`.
+- link:
+    ~/.dotfiles/tools/ssh/config:
+      path: ~/.dotfiles-private/ssh/config
+      force: true
+      canonicalize: false
+      if: '[ -f ~/.dotfiles-private/ssh/config ]'
+
 - shell:
     - command: |
         # Create symlinks for all files in private git directory
@@ -44,20 +56,20 @@
       description: "Link private Cursor files to dotfiles/apps/cursor/"
 
     - command: |
-        # Create symlinks for SSH configs from private repo
-        if [ -f ~/.dotfiles-private/ssh/config ]; then
-          ln -sf ~/.dotfiles-private/ssh/config ~/.dotfiles/tools/ssh/config
-          echo "Linked private SSH config"
-        fi
-        if [ -d ~/.dotfiles-private/ssh/configs ]; then
-          ln -sf ~/.dotfiles-private/ssh/configs ~/.dotfiles/tools/ssh/configs
-          echo "Linked private SSH configs folder"
-        fi
-        if [ -d ~/.dotfiles-private/ssh/keys ]; then
-          ln -sf ~/.dotfiles-private/ssh/keys ~/.dotfiles/tools/ssh/keys
-          echo "Linked private SSH keys folder"
-        fi
-      description: "Link private SSH config, configs, and keys to dotfiles/tools/ssh/"
+        # Ensure SSH per-identity directories exist. tools/ssh/configs is
+        # populated with fragment symlinks by the identity yamls
+        # (ssh-personal.yaml, ssh-jbctechsolutions.yaml). tools/ssh/keys is
+        # populated with per-identity subdirs by fetch-ssh-keys.sh, which the
+        # identity yamls invoke. tools/ssh/config itself is symlinked above
+        # via dotbot's native link: (force overwrites the drifted regular
+        # file from before this restructure).
+        #
+        # The prior version of this command tried `ln -sf
+        # ~/.dotfiles-private/ssh/{configs,keys} ~/.dotfiles/tools/ssh/...`,
+        # which produced nested `configs/configs` and `keys/keys` symlinks
+        # because the targets were already non-empty real directories.
+        mkdir -p ~/.dotfiles/tools/ssh/configs ~/.dotfiles/tools/ssh/keys
+      description: "Ensure SSH per-identity directories exist"
 
     - command: |
         # Create symlinks for all secure_profiles from private repo

--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ shells/zsh/zsh.before/*
 
 # SSH - Ignore everything except templates and docs
 tools/ssh/config
+tools/ssh/configs/
 tools/ssh/keys/**/*
 !tools/ssh/keys/**/.gitkeep
 !tools/ssh/**/*.template

--- a/tools/ssh/configs/configs
+++ b/tools/ssh/configs/configs
@@ -1,1 +1,0 @@
-/Users/joel.castillo.cq/.dotfiles-private/ssh/configs

--- a/tools/ssh/configs/tsc
+++ b/tools/ssh/configs/tsc
@@ -1,1 +1,0 @@
-../../../../.dotfiles-private/ssh/configs/tsc


### PR DESCRIPTION
## Summary

The SSH block in \`.dotbot/configs/private.yaml\` ran:

\`\`\`
ln -sf ~/.dotfiles-private/ssh/configs ~/.dotfiles/tools/ssh/configs
ln -sf ~/.dotfiles-private/ssh/keys    ~/.dotfiles/tools/ssh/keys
\`\`\`

Against non-empty existing directories, \`ln -sf\` does NOT replace the target — it descends into it and creates \`dest/<basename>\`. That produced two nested symlinks (one of them committed to this repo by an earlier checkpoint):

- \`tools/ssh/configs/configs → .dotfiles-private/ssh/configs\`
- \`tools/ssh/configs/tsc     → ../../../../.dotfiles-private/ssh/configs/tsc\`

(Same antipattern also produced \`tools/ssh/keys/keys\` nested symlink, removed from disk during execution.)

## Fix

1. **Replace \`tools/ssh/config\` shell ln-sf with native dotbot \`link:\`** using \`force:true\` + \`canonicalize:false\`. \`force\` is needed exactly once — overwrites a drifted regular file on the first run, then becomes a no-op (dotbot's idempotency check short-circuits). \`canonicalize:false\` preserves the \`~/...\` target instead of resolving through \`realpath\`.
2. **Drop the two directory-level \`ln -sf\` commands.** \`tools/ssh/configs/\` is populated with fragment symlinks by the per-identity yamls (\`ssh-personal.yaml\`, \`ssh-jbctechsolutions.yaml\` in dotfiles-private); \`tools/ssh/keys/\` is populated with per-identity subdirs by \`fetch-ssh-keys.sh\`. Neither dir should ever be a symlink itself.
3. **\`git rm --cached\` the two tracked nested symlinks** and add \`tools/ssh/configs/\` to \`.gitignore\` so the directory contents stay machine-local.

## Companion PR

joelbcastillo/dotfiles-private#fix/ssh-configs — carves host blocks into per-identity fragments and adds the wiring that creates the fragment symlinks via this fixed-up \`private.yaml\`.

## Testing

\`./install private\` runs cleanly. \`ssh -G\` diff against pre-execution baseline (11 hosts) shows only intentional changes; zero regressions. \`ls ~/.dotfiles/tools/ssh/configs/\` shows only per-identity fragment symlinks (no nested \`configs/configs\`).

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: single-user dotfiles change. Validation is the \`ssh -G\` diff in the companion PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)