### PR TITLE
chore: gitignore symlinks materialized by setup-private-files.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,17 @@ tools/aws/*/credentials
 apps/vscode/*-settings.json.context/
 .dotfiles.code-workspace
 .dmux/
+
+# Symlinks materialized at install time by scripts/setup-private-files.sh
+# (points into ~/.dotfiles-private/). Tracked symlinks drift on every run
+# because the script writes absolute paths; matches the SSH precedent.
+apps/vscode/settings.json
+apps/cursor/settings.json
+shells/oh-my-zsh/custom/secure_profiles/ai
+shells/oh-my-zsh/custom/secure_profiles/aws
+shells/oh-my-zsh/custom/secure_profiles/claude
+shells/oh-my-zsh/custom/secure_profiles/jbctech_cloud
+shells/zsh/zsh.before/aliases.zsh
+shells/zsh/zsh.before/company-aliases.zsh
+tools/git/gitconfig.carequant
+tools/git/gitconfig.personal

--- a/apps/cursor/settings.json
+++ b/apps/cursor/settings.json
@@ -1,1 +1,0 @@
-../../../.dotfiles-private/cursor/settings.json

--- a/apps/vscode/settings.json
+++ b/apps/vscode/settings.json
@@ -1,1 +1,0 @@
-../../../.dotfiles-private/vscode/settings.json

--- a/shells/oh-my-zsh/custom/secure_profiles/ai
+++ b/shells/oh-my-zsh/custom/secure_profiles/ai
@@ -1,1 +1,0 @@
-../../../../../.dotfiles-private/shells/secure_profiles/ai

--- a/shells/oh-my-zsh/custom/secure_profiles/aws
+++ b/shells/oh-my-zsh/custom/secure_profiles/aws
@@ -1,1 +1,0 @@
-../../../../../.dotfiles-private/shells/secure_profiles/aws

--- a/shells/oh-my-zsh/custom/secure_profiles/claude
+++ b/shells/oh-my-zsh/custom/secure_profiles/claude
@@ -1,1 +1,0 @@
-../../../../../.dotfiles-private/shells/secure_profiles/claude

--- a/shells/oh-my-zsh/custom/secure_profiles/jbctech_cloud
+++ b/shells/oh-my-zsh/custom/secure_profiles/jbctech_cloud
@@ -1,1 +1,0 @@
-../../../../../.dotfiles-private/shells/secure_profiles/jbctech_cloud

--- a/shells/zsh/zsh.before/aliases.zsh
+++ b/shells/zsh/zsh.before/aliases.zsh
@@ -1,1 +1,0 @@
-../../../../.dotfiles-private/aliases/aliases.zsh

--- a/shells/zsh/zsh.before/company-aliases.zsh
+++ b/shells/zsh/zsh.before/company-aliases.zsh
@@ -1,1 +1,0 @@
-../../../../.dotfiles-private/aliases/company-aliases.zsh

--- a/tools/git/gitconfig.carequant
+++ b/tools/git/gitconfig.carequant
@@ -1,1 +1,0 @@
-../../../.dotfiles-private/git/gitconfig.carequant

--- a/tools/git/gitconfig.personal
+++ b/tools/git/gitconfig.personal
@@ -1,1 +1,0 @@
-../../../.dotfiles-private/git/gitconfig.personal


### PR DESCRIPTION
## Summary

\`scripts/setup-private-files.sh\` runs \`ln -sf "\$abs_source" "\$abs_target"\` for every private file. That writes absolute-path symlink targets. The 10 affected symlinks were tracked in this repo with their original relative-path targets, so every \`./install private\` run flips them to absolute paths and produces spurious diffs in \`git status\`.

Same precedent as \`tools/ssh/config\` (gitignored in PR #47): untrack the symlinks, gitignore them, let \`./install private\` materialize them on each machine.

## Affected symlinks

\`\`\`
apps/vscode/settings.json
apps/cursor/settings.json
shells/oh-my-zsh/custom/secure_profiles/{ai,aws,claude,jbctech_cloud}
shells/zsh/zsh.before/{aliases.zsh,company-aliases.zsh}
tools/git/gitconfig.{carequant,personal}
\`\`\`

## Alternative considered

A cleaner long-term fix is teaching \`setup-private-files.sh\` to write **relative** symlink targets (via Python \`os.path.relpath\` or perl \`File::Spec->abs2rel\`), which would restore portability and let these files stay tracked. Not done here — gitignore is the smaller change. Worth a separate issue if the documentation value of the tracked symlinks turns out to matter.

## Testing

After merge + \`./install private\`, \`git status\` should be clean on these paths (they're now untracked + ignored).

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: housekeeping change. The materialized symlinks themselves are unchanged — only their tracking status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)