### PR TITLE
chore(install): auto-run ./install private after merges that touch private-linked paths

### DIFF
--- a/scripts/git-hooks/post-merge
+++ b/scripts/git-hooks/post-merge
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Auto-run ./install private after a merge that may have updated tracked
+# state for files materialized by setup-private-files.sh.
+#
+# Why this exists: a number of symlinks pointing into ~/.dotfiles-private/
+# are gitignored in this repo and materialized at install time. If an
+# incoming commit did `git rm --cached` on one of those (or added a new
+# private file), `git pull` deletes the working-tree symlink (or fails
+# to create the new one). Re-running `./install private` is idempotent
+# and fast (a few seconds, no network calls), so we just always do it.
+#
+# Enable on this clone with:
+#   git config --local core.hooksPath scripts/git-hooks
+# The ./install bootstrap step does this automatically.
+
+set -e
+
+# Resolve dotfiles root via the symlink that always exists on a configured
+# machine. Don't depend on $PWD — git invokes hooks from arbitrary cwds.
+DOTFILES_ROOT="${HOME}/.dotfiles"
+
+if [ ! -x "${DOTFILES_ROOT}/install" ]; then
+  exit 0
+fi
+
+# Only run when the merge actually touched something setup-private-files.sh
+# cares about. HEAD@{1} is the pre-merge HEAD; HEAD is post-merge.
+if git diff-tree --name-only -r HEAD@{1} HEAD 2>/dev/null | grep -qE '^(\.gitignore|scripts/setup-private-files\.sh|apps/|shells/|tools/(git|ssh|claude|finicky|sshop)/|\.dotbot/configs/private\.yaml)'; then
+  echo "[post-merge] re-running ./install private (incoming changes touched private-linked paths)"
+  cd "${DOTFILES_ROOT}" && ./install private
+fi

--- a/scripts/setup-private-files.sh
+++ b/scripts/setup-private-files.sh
@@ -138,6 +138,15 @@ setup_private_files() {
 
     cd "$DOTFILES_DIR"
 
+    # Enable the tracked git hooks in both repos. The post-merge hook auto-
+    # runs `./install private` after any pull that touches private-linked
+    # paths, so gitignored symlinks (vscode/cursor/secure_profiles/etc.) get
+    # re-materialized on update. Idempotent — safe to run every install.
+    git -C "$DOTFILES_DIR" config --local core.hooksPath scripts/git-hooks
+    if [ -d "$PRIVATE_DIR/scripts/git-hooks" ]; then
+        git -C "$PRIVATE_DIR" config --local core.hooksPath scripts/git-hooks
+    fi
+
     # Show active profile if set
     if [ -n "$ACTIVE_PROFILE" ]; then
         print_message "${BLUE}" "📋 Active profile: $ACTIVE_PROFILE"


### PR DESCRIPTION
## Summary

Adds a tracked \`post-merge\` git hook under \`scripts/git-hooks/\` that auto-runs \`./install private\` when a merge touches paths \`setup-private-files.sh\` materializes into. Prevents the breakage class hit on 2026-05-20 when PR #48 untracked the secure_profile / vscode / cursor / etc. symlinks: \`git pull\` deleted them from the working tree, breaking the next consumer (\`chmox ai\` got "Profile 'ai' not found").

## Mechanism

- Hook lives at \`scripts/git-hooks/post-merge\`. Tracked, executable, no per-clone copies needed.
- Enabled per-clone via \`git config --local core.hooksPath scripts/git-hooks\`.
- \`scripts/setup-private-files.sh\` sets this config on both repos (\`~/.dotfiles\` and \`~/.dotfiles-private\`) as part of every \`./install private\` cycle — so existing clones pick it up the next time \`./install private\` runs, no manual step.
- The hook itself filters via \`git diff-tree --name-only HEAD@{1} HEAD\` against the prefix list that \`setup-private-files.sh\` cares about. Feature-branch merges that touch only unrelated paths skip the install step.
- Idempotent; a few seconds when triggered; no network calls.

## Companion PR

joelbcastillo/dotfiles-private#9 — same hook on the private side, with an extra step to \`chmod 600\` \`ssh/config\` after merge (git resets perms to umask on rewrites, OpenSSH refuses loose-perm configs, the failure mode locks out subsequent git-over-ssh fetches).

## Testing

- \`git config --local core.hooksPath scripts/git-hooks\` set on this clone manually for this PR; \`setup-private-files.sh\` will do it automatically on subsequent runs.
- Hook is exercised on the next \`git pull\` that merges this PR. Expected output: \`[post-merge] re-running ./install private (incoming changes touched private-linked paths)\` followed by the install log.

## Post-Deploy Monitoring & Validation

Watch for the hook log line on the next pull. If \`./install private\` fails inside the hook, the merge still completes (\`set -e\` in the hook + uncaught error → non-zero exit → git prints the failure but does not roll back the merge). If you see a hook failure, just re-run \`./install private\` manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)