### PR TITLE
fix(install): relative symlinks + delegate private.yaml + restore tracking

### DIFF
--- a/.dotbot/configs/private.yaml
+++ b/.dotbot/configs/private.yaml
@@ -1,146 +1,25 @@
-# Private repository integration configuration
-# This configuration creates symlinks to private files from the dotfiles-private repository
-# to the locations where the original dotbot configs expect them
-
-# Base SSH config: swap the regular file in for a symlink to the private
-# canonical. `force: true` is needed here exactly once — it overwrites a
-# drifted regular file on first run, then becomes a no-op (the `link.py`
-# idempotency check short-circuits). `canonicalize: false` preserves the
-# `~/...` target instead of resolving through `realpath`.
-- link:
-    ~/.dotfiles/tools/ssh/config:
-      path: ~/.dotfiles-private/ssh/config
-      force: true
-      canonicalize: false
-      if: '[ -f ~/.dotfiles-private/ssh/config ]'
+# Private repository integration.
+#
+# This config delegates to scripts/setup-private-files.sh — the same
+# implementation `./install private` runs. Calling `./install config private`
+# produces identical output (relative symlink targets via perl
+# File::Spec->abs2rel), so the two install entry points stay in sync.
+#
+# History: this file used to be a single `- shell:` block with one
+# `for file in private/X/*; do ln -sf "$file" public/X/; done` loop per
+# subdir. Two problems with that pattern:
+#   1. `ln -sf` against a non-empty target DIRECTORY silently created a
+#      nested symlink inside it instead of replacing it. Observed on
+#      2026-05-20 with `tools/ssh/configs/configs` and `tools/ssh/keys/keys`.
+#   2. The shell loops expanded glob results to absolute paths, so the
+#      resulting symlink targets were absolute. That drifted against the
+#      relative targets committed in the public repo (and now produced by
+#      setup-private-files.sh via perl File::Spec).
+#
+# Why not use dotbot's native `link: glob: true`? Dotbot writes absolute
+# symlink targets (no `relative` option), which has the same drift issue.
+# Routing both install paths through the shell script avoids it.
 
 - shell:
-    - command: |
-        # Create symlinks for all files in private git directory
-        for file in ~/.dotfiles-private/git/*; do
-          if [ -f "$file" ]; then
-            filename=$(basename "$file")
-            ln -sf "$file" ~/.dotfiles/tools/git/"$filename"
-          fi
-        done
-      description: "Link private git files to dotfiles/tools/git/"
-
-    - command: |
-        # Create symlinks for all files in private aliases directory
-        for file in ~/.dotfiles-private/aliases/*; do
-          if [ -f "$file" ]; then
-            filename=$(basename "$file")
-            ln -sf "$file" ~/.dotfiles/shells/zsh/zsh.before/"$filename"
-          fi
-        done
-      description: "Link private aliases to dotfiles/shells/zsh/zsh.before/"
-
-    - command: |
-        # Create symlinks for all files in private vscode directory
-        for file in ~/.dotfiles-private/vscode/*; do
-          if [ -f "$file" ]; then
-            filename=$(basename "$file")
-            ln -sf "$file" ~/.dotfiles/apps/vscode/"$filename"
-          fi
-        done
-      description: "Link private VS Code files to dotfiles/apps/vscode/"
-
-    - command: |
-        # Create symlinks for all files in private cursor directory
-        for file in ~/.dotfiles-private/cursor/*; do
-          if [ -f "$file" ]; then
-            filename=$(basename "$file")
-            ln -sf "$file" ~/.dotfiles/apps/cursor/"$filename"
-          fi
-        done
-      description: "Link private Cursor files to dotfiles/apps/cursor/"
-
-    - command: |
-        # Ensure SSH per-identity directories exist. tools/ssh/configs is
-        # populated with fragment symlinks by the identity yamls
-        # (ssh-personal.yaml, ssh-jbctechsolutions.yaml). tools/ssh/keys is
-        # populated with per-identity subdirs by fetch-ssh-keys.sh, which the
-        # identity yamls invoke. tools/ssh/config itself is symlinked above
-        # via dotbot's native link: (force overwrites the drifted regular
-        # file from before this restructure).
-        #
-        # The prior version of this command tried `ln -sf
-        # ~/.dotfiles-private/ssh/{configs,keys} ~/.dotfiles/tools/ssh/...`,
-        # which produced nested `configs/configs` and `keys/keys` symlinks
-        # because the targets were already non-empty real directories.
-        mkdir -p ~/.dotfiles/tools/ssh/configs ~/.dotfiles/tools/ssh/keys
-      description: "Ensure SSH per-identity directories exist"
-
-    - command: |
-        # Create symlinks for all secure_profiles from private repo
-        # Ensure target directory exists
-        mkdir -p ~/.dotfiles/shells/oh-my-zsh/custom/secure_profiles
-        if [ -d ~/.dotfiles-private/shells/secure_profiles ]; then
-          for profile in ~/.dotfiles-private/shells/secure_profiles/*; do
-            if [ -f "$profile" ]; then
-              profile_name=$(basename "$profile")
-              ln -sf "$profile" ~/.dotfiles/shells/oh-my-zsh/custom/secure_profiles/"$profile_name"
-              echo "Linked secure profile $profile_name"
-            fi
-          done
-        fi
-      description: "Link private secure_profiles to dotfiles/shells/oh-my-zsh/custom/secure_profiles/"
-
-    - command: |
-        # Create symlinks for all dotbot configs from private repo
-        # This supports any profile-specific configs (personal, work, client1, etc.)
-        if [ -d ~/.dotfiles-private/dotbot ]; then
-          for config in ~/.dotfiles-private/dotbot/*.yaml; do
-            if [ -f "$config" ]; then
-              config_name=$(basename "$config")
-              ln -sf "$config" ~/.dotfiles/.dotbot/configs/"$config_name"
-              echo "Linked private $config_name config"
-            fi
-          done
-        fi
-      description: "Link all private dotbot configs to dotfiles/.dotbot/configs/"
-
-    - command: |
-        # Create symlinks for all Claude tools from private repo
-        if [ -d ~/.dotfiles-private/tools/claude ]; then
-          mkdir -p ~/.dotfiles/tools/claude
-          for file in ~/.dotfiles-private/tools/claude/*; do
-            if [ -f "$file" ]; then
-              filename=$(basename "$file")
-              ln -sf "$file" ~/.dotfiles/tools/claude/"$filename"
-              echo "Linked private Claude tool $filename"
-            fi
-          done
-        fi
-      description: "Link private Claude tools to dotfiles/tools/claude/"
-
-    - command: |
-        # Create symlinks for Finicky configuration from private repo
-        if [ -d ~/.dotfiles-private/tools/finicky ]; then
-          mkdir -p ~/.dotfiles/tools/finicky
-          for file in ~/.dotfiles-private/tools/finicky/*; do
-            if [ -f "$file" ]; then
-              filename=$(basename "$file")
-              ln -sf "$file" ~/.dotfiles/tools/finicky/"$filename"
-              echo "Linked private Finicky config $filename"
-            fi
-          done
-        fi
-      description: "Link private Finicky configuration to dotfiles/tools/finicky/"
-
-    - command: |
-        # Create symlinks for sshop configuration from private repo
-        if [ -d ~/.dotfiles-private/sshop ]; then
-          mkdir -p ~/.dotfiles/tools/sshop
-          for file in ~/.dotfiles-private/sshop/*; do
-            if [ -f "$file" ]; then
-              filename=$(basename "$file")
-              ln -sf "$file" ~/.dotfiles/tools/sshop/"$filename"
-              echo "Linked private sshop config $filename"
-            fi
-          done
-        fi
-      description: "Link private sshop configuration to dotfiles/tools/sshop/"
-
-    - command: echo "Private files symlinked to dotfiles directories successfully"
-      description: "Verify private file symlinks to dotfiles"
+    - command: ${HOME}/.dotfiles/scripts/setup-private-files.sh
+      description: "Materialize private symlinks (via shared setup-private-files.sh)"

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,10 @@ tools/git/*
 !tools/git/gitignore_global
 !tools/git/headless-signing-config.sh
 !tools/git/lazygit.yaml
+# Per-identity gitconfigs are symlinks into ~/.dotfiles-private/git/; tracked
+# with relative targets so the symlink itself documents the wiring.
+!tools/git/gitconfig.carequant
+!tools/git/gitconfig.personal
 
 # Zsh before directory - ignore everything except allowed files
 shells/zsh/zsh.before/*
@@ -77,6 +81,9 @@ shells/zsh/zsh.before/*
 !shells/zsh/zsh.before/rm.zsh
 !shells/zsh/zsh.before/zmv.zsh
 !shells/zsh/zsh.before/zoxide.zsh
+# Aliases/company-aliases are symlinks into ~/.dotfiles-private/aliases/.
+!shells/zsh/zsh.before/aliases.zsh
+!shells/zsh/zsh.before/company-aliases.zsh
 !shells/zsh/zsh.before/aliases.zsh.template
 
 # Template files (these are the public versions)
@@ -108,16 +115,8 @@ apps/vscode/*-settings.json.context/
 .dotfiles.code-workspace
 .dmux/
 
-# Symlinks materialized at install time by scripts/setup-private-files.sh
-# (points into ~/.dotfiles-private/). Tracked symlinks drift on every run
-# because the script writes absolute paths; matches the SSH precedent.
-apps/vscode/settings.json
-apps/cursor/settings.json
-shells/oh-my-zsh/custom/secure_profiles/ai
-shells/oh-my-zsh/custom/secure_profiles/aws
-shells/oh-my-zsh/custom/secure_profiles/claude
-shells/oh-my-zsh/custom/secure_profiles/jbctech_cloud
-shells/zsh/zsh.before/aliases.zsh
-shells/zsh/zsh.before/company-aliases.zsh
-tools/git/gitconfig.carequant
-tools/git/gitconfig.personal
+# (Previously gitignored: symlinks materialized at install time by
+# scripts/setup-private-files.sh. The script now writes RELATIVE
+# symlink targets via perl File::Spec, so they're portable across
+# machines and idempotent against committed values. The files are
+# tracked again — see git history for the un-gitignore commit.)

--- a/README.md
+++ b/README.md
@@ -160,6 +160,30 @@ This template supports secure handling of personal configurations through a sepa
 
 📚 **Full guide:** [Private Setup Documentation](docs/private-setup.md)
 
+### Auto-install on pull
+
+Both `~/.dotfiles` and `~/.dotfiles-private` ship a tracked git hook at
+`scripts/git-hooks/post-merge`. The hook is enabled per-clone via
+`git config --local core.hooksPath scripts/git-hooks`, which
+`./install private` sets automatically (so existing clones pick it up
+on the next install cycle; fresh clones get it on first run).
+
+What it does:
+- After any `git pull` whose changes touched paths that
+  `setup-private-files.sh` materializes (apps/, shells/, tools/git/,
+  tools/ssh/, dotbot/, etc.), the hook re-runs `./install private` so
+  symlinks stay current. Idempotent; a few seconds; no network calls.
+- On the private side, the hook also `chmod 600`s `ssh/config` after
+  every merge — git uses the user's umask when materializing merged
+  files, which can produce `0664` perms that OpenSSH refuses (the
+  failure surfaces as `Bad owner or permissions on ~/.ssh/config` and
+  silently breaks subsequent git-over-ssh fetches).
+
+Symlinks created by `setup-private-files.sh` use **relative** targets
+(computed via `perl File::Spec`), so they're portable across machines
+and committed values match what the script generates — no spurious
+diffs in `git status` after install.
+
 ## 🎯 Default Profile
 
 The default profile includes essential development tools and configurations:

--- a/apps/cursor/settings.json
+++ b/apps/cursor/settings.json
@@ -1,0 +1,1 @@
+../../../.dotfiles-private/cursor/settings.json

--- a/apps/vscode/settings.json
+++ b/apps/vscode/settings.json
@@ -1,0 +1,1 @@
+../../../.dotfiles-private/vscode/settings.json

--- a/scripts/setup-private-files.sh
+++ b/scripts/setup-private-files.sh
@@ -76,6 +76,13 @@ PRIVATE_SUBDIRS=(
     "shells/secure_profiles"
 )
 
+# Compute path of $1 relative to directory $2. Uses perl's File::Spec
+# because BSD realpath on macOS doesn't have GNU's --relative-to flag.
+# Perl ships with macOS, so no extra dep.
+_rel_path() {
+    perl -MFile::Spec -e 'print File::Spec->abs2rel($ARGV[0], $ARGV[1])' "$1" "$2"
+}
+
 # Link files from a directory with optional prefix
 link_directory_files() {
     local source_dir=$1
@@ -92,13 +99,17 @@ link_directory_files() {
 
     local linked_count=0
 
-    # Link all files from source to target
+    # Link all files from source to target. Relative symlink targets keep
+    # the symlinks portable across machines (different $HOME paths) and
+    # idempotent against the committed-symlink values, so `git status` stays
+    # clean after every install.
     for file in "$source_dir"/*; do
         if [ -f "$file" ]; then
             local filename=$(basename "$file")
             local target_file="$target_dir/${prefix}${filename}"
+            local rel_src=$(_rel_path "$file" "$target_dir")
 
-            ln -sf "$file" "$target_file"
+            ln -sf "$rel_src" "$target_file"
             print_message "${GREEN}" "  ✅ Linked ${prefix}${filename}" >&2
             ((linked_count++))
         fi

--- a/scripts/setup-private-files.sh
+++ b/scripts/setup-private-files.sh
@@ -129,13 +129,22 @@ link_directory_files() {
 
 # Function to setup private repository
 setup_private_files() {
-    if [ -z "$PRIVATE_REPO_URL" ]; then
-        print_message "${YELLOW}" "No private repository URL provided."
+    # PRIVATE_REPO_URL is only required to CLONE the private repo for the
+    # first time. If a clone already exists, we can re-materialize symlinks
+    # (and `git pull` against the embedded remote) without the URL — this
+    # is the path .dotbot/configs/private.yaml takes when invoked via
+    # `./install config private`.
+    if [ -z "$PRIVATE_REPO_URL" ] && [ ! -d "$PRIVATE_DIR" ]; then
+        print_message "${YELLOW}" "No private repository URL provided and no existing clone at $PRIVATE_DIR."
         print_message "${BLUE}" "Usage: PRIVATE_REPO_URL=https://github.com/yourusername/dotfiles-private.git ./scripts/setup-private-files.sh"
         return 1
     fi
 
-    print_message "${BLUE}" "🔒 Setting up private files from: $PRIVATE_REPO_URL"
+    if [ -n "$PRIVATE_REPO_URL" ]; then
+        print_message "${BLUE}" "🔒 Setting up private files from: $PRIVATE_REPO_URL"
+    else
+        print_message "${BLUE}" "🔒 Updating private files (existing clone at $PRIVATE_DIR)"
+    fi
 
     # Clone or update private repository
     if [ -d "$PRIVATE_DIR" ]; then

--- a/shells/oh-my-zsh/custom/secure_profiles/ai
+++ b/shells/oh-my-zsh/custom/secure_profiles/ai
@@ -1,0 +1,1 @@
+../../../../../.dotfiles-private/shells/secure_profiles/ai

--- a/shells/oh-my-zsh/custom/secure_profiles/aws
+++ b/shells/oh-my-zsh/custom/secure_profiles/aws
@@ -1,0 +1,1 @@
+../../../../../.dotfiles-private/shells/secure_profiles/aws

--- a/shells/oh-my-zsh/custom/secure_profiles/claude
+++ b/shells/oh-my-zsh/custom/secure_profiles/claude
@@ -1,0 +1,1 @@
+../../../../../.dotfiles-private/shells/secure_profiles/claude

--- a/shells/oh-my-zsh/custom/secure_profiles/jbctech_cloud
+++ b/shells/oh-my-zsh/custom/secure_profiles/jbctech_cloud
@@ -1,0 +1,1 @@
+../../../../../.dotfiles-private/shells/secure_profiles/jbctech_cloud

--- a/shells/zsh/zsh.before/aliases.zsh
+++ b/shells/zsh/zsh.before/aliases.zsh
@@ -1,0 +1,1 @@
+../../../../.dotfiles-private/aliases/aliases.zsh

--- a/shells/zsh/zsh.before/company-aliases.zsh
+++ b/shells/zsh/zsh.before/company-aliases.zsh
@@ -1,0 +1,1 @@
+../../../../.dotfiles-private/aliases/company-aliases.zsh

--- a/tools/git/gitconfig.carequant
+++ b/tools/git/gitconfig.carequant
@@ -1,0 +1,1 @@
+../../../.dotfiles-private/git/gitconfig.carequant

--- a/tools/git/gitconfig.personal
+++ b/tools/git/gitconfig.personal
@@ -1,0 +1,1 @@
+../../../.dotfiles-private/git/gitconfig.personal


### PR DESCRIPTION
## Summary

Three interlocking fixes that together eliminate the spurious-diff problem after \`./install private\` / \`./install config private\`, restore documentation value to the public repo, and harden the dotbot path:

1. **\`setup-private-files.sh\` writes RELATIVE symlink targets** via \`perl File::Spec->abs2rel\` (perl ships with macOS, no extra dep). Targets become portable across machines and idempotent against committed values.
2. **10 symlinks become tracked again** (\`apps/{vscode,cursor}/settings.json\`, \`shells/oh-my-zsh/custom/secure_profiles/*\`, \`shells/zsh/zsh.before/{aliases,company-aliases}.zsh\`, \`tools/git/gitconfig.{carequant,personal}\`). PR #48 had to gitignore them because they drifted; with relative targets, they don't.
3. **\`.dotbot/configs/private.yaml\` delegates to \`setup-private-files.sh\`** instead of duplicating the linking logic with shell \`ln -sf\` loops that wrote absolute paths. \`./install config private\` (dotbot path) and \`./install private\` (shell path) now produce identical output.

## Commit breakdown

- **\`fix(install): write relative symlink targets + restore tracked symlinks\`** — the perl-relative logic + gitignore cleanup + README doc.
- **\`refactor(dotbot): private.yaml delegates to setup-private-files.sh\`** — collapses 9 shell-loop blocks (~160 lines) into a single shell call, plus loosens \`PRIVATE_REPO_URL\` check so the script works standalone when a clone already exists.

## Why combine into one PR

These changes are inseparable. Without #1, tracking the symlinks (#2) is pointless because they'd drift. Without #3, the dotbot path would write absolute paths and undo #1/#2 every time someone ran \`./install config private\`. Splitting would leave intermediate states with regressions.

## Companion: post-merge hook (PR #49)

The hook stays in place. It catches the case where a future PR adds/removes a private file — the hook auto-re-runs \`./install private\` so the symlinks stay current. Now that the symlinks are relative AND tracked, the hook also serves to update them on every pull where the private side adds new files.

## Testing

- \`./install private\` produces relative-target symlinks: \`readlink apps/vscode/settings.json\` → \`../../../.dotfiles-private/vscode/settings.json\`.
- Subsequent \`./install private\` runs are \`git status\`-clean (idempotent).
- \`./install config private\` produces identical output (delegated to the same script).
- The dotbot path no longer requires \`PRIVATE_REPO_URL\` env var when a clone already exists.

## Post-Deploy Monitoring & Validation

No operational impact beyond install-time behavior. After merge, the next \`./install private\` materializes relative symlinks matching the committed values; future \`git status\` should stay clean on these paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)