### PR TITLE
chore(install): set core.hooksPath in bootstrap too

### DIFF
--- a/install
+++ b/install
@@ -347,7 +347,14 @@ function bootstrap() {
         rollback "$backup_dir"
         return 1
     fi
-    
+
+    # Enable tracked git hooks in this repo. The post-merge hook auto-runs
+    # ./install private when relevant — see scripts/git-hooks/post-merge.
+    # setup-private-files.sh also sets this on every ./install private run,
+    # so this is a belt-and-suspenders for users who run bootstrap but not
+    # (yet) the private setup.
+    git -C "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" config --local core.hooksPath scripts/git-hooks 2>/dev/null || true
+
     green_echo "${SELF_NAME}" "Bootstrap completed successfully"
     if [ $WARNING_COUNT -gt 0 ]; then
         yellow_echo "${SELF_NAME}" "Completed with $WARNING_COUNT warnings"


### PR DESCRIPTION
## Summary

\`scripts/setup-private-files.sh\` sets \`core.hooksPath\` on both \`~/.dotfiles\` and \`~/.dotfiles-private\` (per PR #49). But a fresh-clone user who runs \`./install bootstrap\` without (yet) running \`./install private\` has no post-merge hook enabled — \`git pull\` won't auto-rematerialize symlinks if needed.

This adds the same \`git config --local core.hooksPath scripts/git-hooks\` at the end of \`bootstrap()\`. Idempotent + silent on failure (\`|| true\`) so it can't break bootstrap.

## Testing

After merge, a fresh clone running just \`./install bootstrap\` (no \`private\` step) will have the post-merge hook live. Verified locally that the existing repo's hooksPath is still set after running bootstrap (no regression).

## Post-Deploy Monitoring & Validation

No additional operational monitoring required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)